### PR TITLE
New CalculatePixel functions to use TPA's instead of boxes.

### DIFF
--- a/Units/MMLAddon/LPInc/Wrappers/lp_bitmap.inc
+++ b/Units/MMLAddon/LPInc/Wrappers/lp_bitmap.inc
@@ -262,3 +262,8 @@ procedure Lape_CalculatePixelTolerance(const Params: PParamArray; const Result: 
 begin
   Pextended(Result)^ := ps_CalculatePixelTolerance(PInteger(Params^[0])^, PInteger(Params^[1])^, PBox(Params^[2])^, Pinteger(Params^[3])^);
 end;
+
+procedure Lape_CalculatePixelToleranceTPA(const Params: PParamArray; const Result: Pointer);
+begin
+  Pextended(Result)^ := ps_CalculatePixelToleranceTPA(PInteger(Params^[0])^, PInteger(Params^[1])^, PPointArray(Params^[2])^, Pinteger(Params^[3])^);
+end;

--- a/Units/MMLAddon/LPInc/lpexportedmethods.inc
+++ b/Units/MMLAddon/LPInc/lpexportedmethods.inc
@@ -95,6 +95,7 @@ AddGlobalFunc('function ConvoluteBitmap(bitmap: integer; matrix: T2DExtendedArra
 AddGlobalFunc('function CalculatePixelShift(Bmp1,Bmp2: Integer; CompareBox: TBox): integer', @Lape_CalculatePixelShift);
 AddGlobalFunc('function CalculatePixelShiftTPA(Bmp1,Bmp2 : Integer; CPoints: TPointArray) : integer;', @Lape_CalculatePixelShiftTPA);
 AddGlobalFunc('function CalculatePixelTolerance(Bmp1,Bmp2: Integer; CompareBox: TBox; CTS: integer): extended', @Lape_CalculatePixelTolerance);
+AddGlobalFunc('function CalculatePixelToleranceTPA(Bmp1,Bmp2 : Integer; CPoints: TPointArray; CTS : integer) : extended;', @Lape_CalculatePixelToleranceTPA);
 
 { Math }
 

--- a/Units/MMLAddon/LPInc/lpexportedmethodsinc.inc
+++ b/Units/MMLAddon/LPInc/lpexportedmethodsinc.inc
@@ -51,6 +51,7 @@ AddGlobalFunc('function ConvoluteBitmap(bitmap: integer; matrix: T2DExtendedArra
 AddGlobalFunc('function CalculatePixelShift(Bmp1,Bmp2: Integer; CompareBox: TBox): integer', @Lape_CalculatePixelShift);
 AddGlobalFunc('function CalculatePixelShiftTPA(Bmp1,Bmp2 : Integer; CPoints: TPointArray) : integer;', @Lape_CalculatePixelShiftTPA);
 AddGlobalFunc('function CalculatePixelTolerance(Bmp1,Bmp2: Integer; CompareBox: TBox; CTS: integer): extended', @Lape_CalculatePixelTolerance);
+AddGlobalFunc('function CalculatePixelToleranceTPA(Bmp1,Bmp2 : Integer; CPoints: TPointArray; CTS : integer) : extended;', @Lape_CalculatePixelToleranceTPA);
 AddGlobalFunc('function GetColor(x,y: integer): TColor', @Lape_GetColor);
 AddGlobalFunc('procedure GetColorsWrap(Coords: TPointArray; var Colors: TIntegerArray);', @Lape_GetColorsWrap);
 AddGlobalFunc('function GetColors(const Coords: TPointArray): TIntegerArray', @Lape_GetColors);

--- a/Units/MMLAddon/PSInc/Wrappers/bitmap.inc
+++ b/Units/MMLAddon/PSInc/Wrappers/bitmap.inc
@@ -330,3 +330,9 @@ begin
   with CurrThread.Client.MBitmaps do
     result := CalculatePixelTolerance(GetBMP(bmp1),GetBMP(bmp2),comparebox,cts);
 end;
+
+function ps_CalculatePixelToleranceTPA(Bmp1,Bmp2 : Integer; CPoints: TPointArray; CTS : integer) : extended;extdecl;
+begin
+  with CurrThread.Client.MBitmaps do
+    result := CalculatePixelToleranceTPA(GetBMP(bmp1),GetBMP(bmp2),CPoints,cts);
+end;

--- a/Units/MMLAddon/PSInc/psexportedmethods.inc
+++ b/Units/MMLAddon/PSInc/psexportedmethods.inc
@@ -440,6 +440,7 @@ AddFunction(@ps_ConvoluteBitmap,'function ConvoluteBitmap(bitmap : integer; matr
 AddFunction(@ps_CalculatePixelShift,'function CalculatePixelShift(Bmp1,Bmp2 : Integer; CompareBox : TBox) : integer;');
 AddFunction(@ps_CalculatePixelShiftTPA,'function CalculatePixelShiftTPA(Bmp1,Bmp2 : Integer; CPoints: TPointArray) : integer;');
 AddFunction(@ps_CalculatePixelTolerance,'function CalculatePixelTolerance(Bmp1,Bmp2 : Integer; CompareBox : TBox; CTS : integer) : extended;');
+AddFunction(@ps_CalculatePixelToleranceTPA,'function CalculatePixelToleranceTPA(Bmp1,Bmp2 : Integer; CPoints: TPointArray; CTS : integer) : extended;');
 {$ENDIF}
 
 {tpa}

--- a/Units/MMLCore/bitmaps.pas
+++ b/Units/MMLCore/bitmaps.pas
@@ -129,6 +129,7 @@ type
   function CalculatePixelShift(Bmp1,Bmp2 : TMufasaBitmap; CompareBox : TBox) : integer;
   function CalculatePixelShiftTPA(Bmp1, Bmp2: TMufasaBitmap; CPoints: TPointArray): integer;
   function CalculatePixelTolerance(Bmp1,Bmp2 : TMufasaBitmap; CompareBox : TBox; CTS : integer) : extended;
+  function CalculatePixelToleranceTPA(Bmp1, Bmp2: TMufasaBitmap; CPoints: TPointArray; CTS: integer): extended;
 implementation
 
 uses
@@ -251,6 +252,48 @@ begin
                                       Sqr(Bmp1.FData[y * w1 + x].g-Bmp2.Fdata[y * w2 + x].g) +
                                       Sqr(Bmp1.FData[y * w1 + x].b-Bmp2.Fdata[y * w2 + x].b));
           Result := Result / ((CompareBox.x2 - CompareBox.x1 + 1) * (CompareBox.y2-CompareBox.y1 + 1)); //We want the value for the whole Pixel;
+        end;
+  end;
+end;
+
+function CalculatePixelToleranceTPA(Bmp1, Bmp2: TMufasaBitmap; CPoints: TPointArray;
+  CTS: integer): extended;
+var
+  i : integer;
+  bounds: TBox;
+  w1,w2 : integer;
+  Diff : int64;
+begin
+  bounds := GetTPABounds(CPoints);
+  Bmp1.ValidatePoint(bounds.x1,bounds.y1);
+  Bmp1.ValidatePoint(bounds.x2,bounds.y2);
+  Bmp2.ValidatePoint(bounds.x1,bounds.y1);
+  Bmp2.ValidatePoint(bounds.x2,bounds.y2);
+  Bmp1.SetAlphaValue(0);
+  Bmp2.SetAlphaValue(0);
+  w1 := bmp1.Width;
+  w2 := bmp2.width;
+  result := 0;
+  if not InRange(CTS,0,1) then
+    raise exception.CreateFmt('CTS Passed to CalculateTolerance must be in [0..1], it currently is %d',[CTS]);
+  case CTS of
+    0 : begin
+          Diff := 0;
+          for i := 0 to High(CPoints) do
+            begin
+              Diff := Diff + abs(Bmp1.FData[CPoints[i].y * w1 + CPoints[i].x].r-Bmp2.Fdata[CPoints[i].y * w2 + CPoints[i].x].r) +
+                             abs(Bmp1.FData[CPoints[i].y * w1 + CPoints[i].x].g-Bmp2.Fdata[CPoints[i].y * w2 + CPoints[i].x].g) +
+                             abs(Bmp1.FData[CPoints[i].y * w1 + CPoints[i].x].b-Bmp2.Fdata[CPoints[i].y * w2 + CPoints[i].x].b);
+            end;
+          Result := Diff / (3 * (bounds.x2 - bounds.x1 + 1) * (bounds.y2-bounds.y1 + 1)); //We want the value for the whole Pixel; so divide by 3 (RGB)
+        end;
+    1 : begin
+
+          for i := 0 to High(CPoints) do
+            Result := Result + Sqrt(Sqr(Bmp1.FData[CPoints[i].y * w1 + CPoints[i].x].r-Bmp2.Fdata[CPoints[i].y * w2 + CPoints[i].x].r) +
+                                    Sqr(Bmp1.FData[CPoints[i].y * w1 + CPoints[i].x].g-Bmp2.Fdata[CPoints[i].y * w2 + CPoints[i].x].g) +
+                                    Sqr(Bmp1.FData[CPoints[i].y * w1 + CPoints[i].x].b-Bmp2.Fdata[CPoints[i].y * w2 + CPoints[i].x].b));
+          Result := Result / ((bounds.x2 - bounds.x1 + 1) * (bounds.y2-bounds.y1 + 1)); //We want the value for the whole Pixel;
         end;
   end;
 end;


### PR DESCRIPTION
Made this so that I can filter out certain points when checking for pixel shifting. Gives me a better number to work with.
