### PR TITLE
Load the SQLite library dynamicly.

### DIFF
--- a/Units/MMLAddon/msqlite3.pas
+++ b/Units/MMLAddon/msqlite3.pas
@@ -27,7 +27,7 @@ unit msqlite3;
 interface
 
 uses
-  Classes, SysUtils, sqlite3dyn, math, Forms, Zipper, httpsend, newsimbasettings;
+  Classes, SysUtils, sqlite3dyn, math;
 
 type
   TStringArray = array of string;
@@ -57,6 +57,9 @@ implementation
 
 uses
   Client;
+
+var
+  SQLite3Loaded: boolean = False;
 
 // http://sqlite.org/c3ref/errcode.html
 function TMSQLite3.errcode(index : integer) : integer;
@@ -119,6 +122,9 @@ var
   l, ecode : integer;
   emsg : string;
 begin
+  if (not (SQLite3Loaded)) then
+    raise EInOutError.Create('SQLite library not loaded.');
+
   l := length(ConnList);
   SetLength(ConnList, l + 1);
   result := l;
@@ -197,63 +203,17 @@ begin
   inherited Destroy;
 end;
 
-var
-  Loaded: boolean = False;
-
-function DownloadSQLite(): boolean;
-var
-  TempFile, TempDir, Filename: string;
-  FileStream: TFileStream;
-begin
-  Result := False;
-  TempFile := GetTempFileName();
-  TempDir := IncludeTrailingPathDelimiter(GetTempDir());
-
-  FileStream := TFileStream.Create(TempFile, fmCreate or fmOpenReadWrite);
-  try
-    Result := HttpGetBinary('http://www.sqlite.org/sqlite-dll-win32-x86-3071000.zip', FileStream);
-    if (not (Result)) then
-      Exit;
-  finally
-    FileStream.Free;
-  end;
-
-  with TUnZipper.Create() do
-  try
-    FileName := TempFile;
-    OutputPath := TempDir;
-    Examine;
-    UnZipAllFiles();
-  finally
-    Free;
-  end;
-
-  Filename := 'sqlite3.' + {$IFDEF WINDOWS}'dll'{$ELSE}'so'{$ENDIF};
-  TempFile := TempDir + Filename;
-  TempDir := IncludeTrailingPathDelimiter(Application.Location) + Filename;
-
-  Result := FileExists(TempFile) and RenameFile(TempFile, TempDir);
-end;
-
 initialization
   try
     InitialiseSQLite();
-    Loaded := True;
+    SQLite3Loaded := True;
   except
-    on e: exception do
+    on e: EInOutError do
     begin
       WriteLn(e.Message);
-      WriteLn('Gonna try downloading SQLite...');
-      if (DownloadSQLite()) then
-      try
-        InitialiseSQLite();
-        Loaded := True;
-      except
-        WriteLn('Unable to download sqlite3.dll!');
-      end;
+      WriteLn('You can find the library at "http://www.sqlite.org/".');
     end;
   end;
 finalization
-  if (Loaded) then
-    ReleaseSQLite();
+  ReleaseSQLite();
 end.


### PR DESCRIPTION
Doing it this way allows us to catch the Exception for the library being missing and "disable" the functionality.
