### PR TITLE
Small function name edit

### DIFF
--- a/Units/MMLAddon/PSInc/psexportedmethods.inc
+++ b/Units/MMLAddon/PSInc/psexportedmethods.inc
@@ -194,7 +194,7 @@ AddFunction(@ps_GetTimeRunning,'function GetTimeRunning: LongWord;');
 AddFunction(@ps_DecodeTime,'procedure DecodeTime(DateTime : TDateTime; var Hour,Min,Sec,MSec : word);');
 AddFunction(@ps_DecodeDate,'procedure DecodeDate ( const SourceDate  : TDateTime; var Year, Month, Day  : Word );');
 AddFunction(@ps_ConvertTime,'procedure ConvertTime(Time: integer; var h, m, s: integer);');
-AddFunction(@ps_ConvertTime,'procedure ConvertTime64(time: int64; var y, m, w, d, h, min, s: integer);');
+AddFunction(@ps_ConvertTime64,'procedure ConvertTime64(time: int64; var y, m, w, d, h, min, s: integer);');
 AddFunction(@ps_HakunaMatata,'procedure HakunaMatata;');
 AddFunction(@ps_Simba,'procedure Simba;');
 AddFunction(@ps_PlaySound,'procedure PlaySound( Sound : string);');


### PR DESCRIPTION
Had forgotten to include "64" to the line:
AddFunction(@ps_ConvertTime,'procedure ConvertTime64(time: int64; var y, m, w, d, h, min, s: integer);');

Specifically here:
@ps_ConvertTime[64]
- Thus, the pull req to update this to say 64. (Other files containing method were checked too, and didn't include this mistake)
