### PR TITLE
Fix DebugImage going out of reach.

### DIFF
--- a/Projects/Simba/debugimage.pas
+++ b/Projects/Simba/debugimage.pas
@@ -56,7 +56,7 @@ var
 implementation
 
 uses
-  MufasaTypes, math, graphtype, IntfGraphics,SimbaUnit,lclintf,colour_conv,InterfaceBase;
+  MufasaTypes, math, graphtype, IntfGraphics,SimbaUnit,lclintf,InterfaceBase;
 { TDebugImgForm }
 
 procedure TDebugImgForm.FormCreate(Sender: TObject);
@@ -106,13 +106,10 @@ end;
 
 procedure TDebugImgForm.ShowDebugImgForm(DispSize : TPoint);
 begin
-  if not Visible then
-    show;
+  if not Visible then 
+    Show;
   if (DispSize.x <> Width) or (DispSize.y  <> height) then
-  begin;
-    Width := DispSize.x;
-    Height := DispSize.y;
-  end;
+    SetBounds(Max(1, Left), Max(1, Top), DispSize.x, DispSize.y);
   FormStyle := fsStayOnTop;
 end;
 


### PR DESCRIPTION
"Display large image" -> "Move outside screen bounds" -> "Display small
image.."
That could cause the image to potensially display the smaller image out
side the screen, resulting in it being unreachable.
