### PR TITLE
Case-insesitve `loadlib`-directive for Lape.

### DIFF
--- a/Units/MMLAddon/mmlpsthread.pas
+++ b/Units/MMLAddon/mmlpsthread.pas
@@ -1522,7 +1522,7 @@ var
   plugin_idx: integer;
 begin
   Result := False;
-  if (not InPeek) and (Directive = 'loadlib') then
+  if (not InPeek) and (CompareText(Directive,'LOADLIB') = 0) then
   begin
     if (Argument <> '') then
     begin


### PR DESCRIPTION
Was lowercase only.. which I found no reason for it to be, so I changed it to be case-insensitive.
