### PR TITLE
  AddOnTerminate now accepts type procedure addresses .

### DIFF
--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -3121,8 +3121,6 @@ begin
   Handled := ActionList.IsShortCut(Msg);
 end;
 
-
-
 procedure TSimbaForm.LabeledEditSearchEnter(Sender: TObject);
 begin
   SearchStart := CurrScript.SynEdit.LogicalCaretXY;
@@ -3262,6 +3260,13 @@ function TSimbaForm.GetInterepterMethods(const SimbaMethods: TExpMethodArr): TEx
         Result += Str[i];
   end;
 
+  function isInternal(const Str: string): Boolean;
+  begin
+    if (Length(Str) = 0) then
+      Exit(False);
+    Result := (Str[1] = '_');
+  end;
+
 var
   Headers, Names, SortedHeaders: TStringList;
   Len, h, i, p: Integer;
@@ -3284,7 +3289,7 @@ begin
       Methods[i] := PrepareStr(Lowercase(SimbaMethods[i].FuncDecl));
 
     for i := 0 to (Names.Count - 1) do
-      if (not IsStrInArr(PrepareStr(Lowercase(Headers[i])), False, Methods)) then
+      if (not IsStrInArr(PrepareStr(Lowercase(Headers[i])), False, Methods)) and (not isInternal(Names[i])) then
         SortedHeaders.Add(Names[i] + '###' + Headers[i]);
 
     for i := 0 to (SortedHeaders.Count - 1) do

--- a/Units/MMLAddon/LPInc/Wrappers/lp_other.inc
+++ b/Units/MMLAddon/LPInc/Wrappers/lp_other.inc
@@ -175,3 +175,16 @@ begin
   ps_ShowBalloonHint(PString(Params^[0])^, PString(Params^[1])^, PInteger(Params^[2])^, PBalloonFlags(Params^[3])^);
 end;
 
+procedure Lape_AddOnTerm_Type(const Params: PParamArray); lape_extdecl
+var
+  L: Integer;
+begin
+  L := Length(CurrThread.OnTermTypeProcs);
+  SetLength(CurrThread.OnTermTypeProcs, L + 1);
+  CurrThread.OnTermTypeProcs[L] := PTypeProc(Params^[0])^;
+end;
+
+procedure Lape_GetOnTerm_Type(const Params: PParamArray; const Result: Pointer); lape_extdecl
+begin
+  PTypeProcArr(Result)^ := CurrThread.OnTermTypeProcs;
+end;

--- a/Units/MMLAddon/LPInc/lpcompile.inc
+++ b/Units/MMLAddon/LPInc/lpcompile.inc
@@ -135,3 +135,7 @@ addGlobalType('array of TOCRFilterData', 'TOCRFilterDataArray');
 
 addGlobalType('(htHaval, htMD4, htMD5, htRIPEMD128, htRIPEMD160, htSHA1, htSHA256, htSHA384, htSHA512, htTiger)', 'THashType');
 
+addGlobalType('procedure of object', 'TTypeProc');
+addGlobalType('array of TTypeProc', 'TTypeProcArray');
+
+addGlobalVar(LineEnding, 'LineEnding').isConstant := True;

--- a/Units/MMLAddon/LPInc/lpexportedmethods.inc
+++ b/Units/MMLAddon/LPInc/lpexportedmethods.inc
@@ -25,6 +25,8 @@
 SetCurrSection('Other');
 //AddGlobalFunc('procedure Writeln(const str: string);', @Lape_Writeln);
 AddGlobalFunc('function AddOnTerminate(const proc: string): Boolean;', @Lape_AddOnTerm);
+AddGlobalFunc('function AddOnTerminate(const Addr: TTypeProc): Boolean; overload;', @Lape_AddOnTerm_Type);
+AddGlobalFunc('function GetOnTerminate(): TTypeProcArray;', @Lape_GetOnTerm_Type);
 AddGlobalFunc('function DeleteOnTerminate(const proc: string): Boolean;', @Lape_DelOnTerm);
 AddGlobalFunc('function SetScriptProp(prop: TSP_Property; Value: TVariantArray): boolean', @Lape_SetScriptProp);
 AddGlobalFunc('function GetScriptProp(prop: TSP_Property; var Value: TVariantArray): boolean', @Lape_GetScriptProp);


### PR DESCRIPTION
(Lape) 
  AddOnTerminate now accepts type procedure addresses, and calls the methods apon termination.
  EG:
      AddOnTerminate(BMP.Free);    [Tests](http://i.imgur.com/8w0YwKd.png)

 Also Exported LineEnding.
