### PR TITLE
Fix: AverageExtended

### DIFF
--- a/Units/MMLCore/tpa.pas
+++ b/Units/MMLCore/tpa.pas
@@ -3188,15 +3188,11 @@ function AverageExtended(const tE: TExtendedArray): Extended;
 var
   i, h: Integer;
 begin
-  Result := 1;
-  try
-    h := High(tE);
-    for i := 0 to h do
-      Result := (Result * tE[i]);
-    Result := Power(Result, 1/(h + 1));
-  except
-    Result := 0.0;
-  end;
+  h := High(tE);
+  if h < 0 then Exit(0);
+  for i := 0 to h do
+    Result := (Result + tE[i]);
+  Result := Result / (H+1);  
 end;
 
 {/\


### PR DESCRIPTION
This fixes the function used to compute the average of an extended-type
array, assuming it should do the same as AverageTIA, which computes the
mean.

Proof that it's broken:

> A := [5,5,0,5,9,7];
> WriteLn( AverageExtended(A) );

Gives `0.0` where it should result in `5.1666...`

And:

> A := [1,2,3,4];
> WriteLn( AverageExtended(A) );

Gives `2.21336` where it should result in `2.5`
