### PR TITLE
Fixed and tidy up font loading, export TCanvas.Handle.

### DIFF
--- a/Projects/Simba/Simba.lpi
+++ b/Projects/Simba/Simba.lpi
@@ -408,7 +408,6 @@
       </CompilerMessages>
       <CustomOptions Value="-dUseCThreads
 -dM_MEMORY_DEBUG
--dFONTDEBUG
 -dLape_CDECL
 -dStaticFFI"/>
       <CompilerPath Value="$(CompPath)"/>

--- a/Projects/Simba/newsimbasettings.pas
+++ b/Projects/Simba/newsimbasettings.pas
@@ -163,7 +163,7 @@ type
       Path: TPathSetting;
       CheckForUpdates: TBooleanSetting;
       LoadOnSimbaStart: TBooleanSetting;
-      LoadOnScriptStart: TBooleanSetting;
+      DisableLoading: TBooleanSetting;
       Version: TIntegerSetting;
       VersionLink: TStringSetting;
       UpdateLink: TStringSetting;
@@ -845,6 +845,7 @@ procedure GetInterpreterAllowSysCalls(obj: TObject); begin TBooleanSetting(obj).
 
 procedure GetFontsCheckForUpdates(obj: TObject); begin TBooleanSetting(obj).Value := True; end;
 procedure GetFontsLoadOnStartUp(obj: TObject); begin TBooleanSetting(obj).Value := True; end;
+procedure GetFontsDisableLoading(obj: TObject); begin TBooleanSetting(obj).Value := False; end;
 procedure GetFontsVersion(obj: TObject); begin TIntegerSetting(obj).Value := -1; end;
 procedure GetFontsVersionLink(obj: TObject); begin TStringSetting(obj).Value := FontURL + 'Version'; end;
 procedure GetFontsUpdateLink(obj: TObject); begin TStringSetting(obj).Value := FontURL + 'Fonts.tar.bz2'; end;
@@ -910,8 +911,8 @@ begin
   Fonts.CheckForUpdates.onDefault := @GetFontsCheckForUpdates;
   Fonts.LoadOnSimbaStart := Fonts.AddChild(TBooleanSetting.Create(ssLoadFontsOnSimbaStart)) as TBooleanSetting;
   Fonts.LoadOnSimbaStart.onDefault := @GetFontsLoadOnStartUp;
-  Fonts.LoadOnScriptStart := Fonts.AddChild(TBooleanSetting.Create(ssLoadFontsOnScriptStart)) as TBooleanSetting;
-  Fonts.LoadOnScriptStart.onDefault := @GetFontsLoadOnStartUp;
+  Fonts.DisableLoading := Fonts.AddChild(TBooleanSetting.Create(ssFontsDisableLoading)) as TBooleanSetting;
+  Fonts.DisableLoading.onDefault := @GetFontsDisableLoading;
   Fonts.Version := Fonts.AddChild(TIntegerSetting.Create(ssFontsVersion)) as TIntegerSetting;
   Fonts.Version.onDefault := @GetFontsVersion;
   Fonts.VersionLink := Fonts.AddChild(TStringSetting.Create(ssFontsVersionLink)) as TStringSetting;

--- a/Projects/Simba/settings_const.inc
+++ b/Projects/Simba/settings_const.inc
@@ -29,7 +29,7 @@ ssUpdaterReleaseChannel = ssSettings + ssUpdater + 'ReleaseChannel';
 
 ssCheckForFontUpdates = ssSettings + ssFonts + 'CheckForUpdates';
 ssLoadFontsOnSimbaStart = ssSettings + ssFonts + 'LoadOnSimbaStart';
-ssLoadFontsOnScriptStart = ssSettings + ssFonts + 'LoadOnScriptStart';
+ssFontsDisableLoading = ssSettings + ssFonts + 'DisableLoading';
 ssFontsVersion = ssSettings + ssFonts + 'Version';
 ssFontsLink = ssSettings + ssFonts + 'UpdateLink';
 ssFontsVersionLink = ssSettings + ssFonts + 'VersionLink';

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -535,7 +535,7 @@ type
     procedure SaveFormSettings;
     procedure LoadExtensions;
     procedure AddRecentFile(const filename : string);
-    procedure InitializeTMThread(out Thread : TMThread);
+    procedure InitializeTMThread(out Thread : TMThread; const onStartup: Boolean = False);
     procedure HandleParameters;
     procedure HandleConfigParameter;
     procedure OnSaveScript(const Filename : string);
@@ -543,6 +543,7 @@ type
     property ShowCodeCompletionAuto: Boolean read GetShowCodeCompletionAuto write SetShowCodeCompletionAuto;
     property CurrHighlighter : TSynCustomHighlighter read GetHighlighter;
     function DefaultScript : string;
+    procedure InitOCR(var OCR: TMOCR; TheThread: TMThread);
 
     procedure UpdateSimbaSilent(Force: Boolean);
   end;
@@ -1299,11 +1300,9 @@ var
   Time, LatestVersion: integer;
 begin
   UpdateTimer.Interval := MaxInt;
-
   if (SimbaSettings.Fonts.CheckForUpdates.GetDefValue(True)) then
-    FontUpdate()
-  else if (SimbaSettings.Fonts.LoadOnSimbaStart.GetDefValue(True)) then
-    OCR_Fonts.InitTOCR(SimbaSettings.Fonts.Path.Value);
+    if (not SimbaSettings.Fonts.DisableLoading.GetDefValue(False)) then
+      FontUpdate();
 
   if (not (SimbaSettings.Updater.CheckForUpdates.GetDefValue(True))) then
     Exit;
@@ -1908,16 +1907,40 @@ begin
     RecentFileItems[len - 1-i].Caption:= ExtractFileName(RecentFiles[i]);
 end;
 
+procedure TSimbaForm.InitOCR(var OCR: TMOCR; TheThread: TMThread);
+var
+  i: Integer;
+  s: String = '';
+begin
+  FormWriteln('Initializing OCR');
+
+  if (TheThread <> nil) then
+    OCR := TMOCR.Create(TheThread.Client)
+  else
+    OCR := TMOCR.Create(nil);
+
+  if (DirectoryExists(SimbaSettings.Fonts.Path.Value)) then
+    OCR.Fonts.Path := SimbaSettings.Fonts.Path.Value;
+  OCR.InitTOCR(SimbaSettings.Fonts.Path.Value);
+
+  for i := 0 to OCR.Fonts.Count - 1 do
+    s += OCR.Fonts[i].Name + ', ';
+
+  if (s <> '') then
+  begin
+    SetLength(s, Length(s) - 2);
+    FormWriteln('Loaded '+ IntToStr(OCR.Fonts.Count) + ' Fonts: ' + s);
+  end else
+    FormWriteln('No fonts were loaded, directory was invaild or empty!');
+end;
 
 { Loads/Creates the required stuff for a script thread. }
 
-procedure TSimbaForm.InitializeTMThread(out Thread: TMThread);
+procedure TSimbaForm.InitializeTMThread(out Thread: TMThread; const onStartup: Boolean = False);
 var
   ScriptPath: string;
   Script: string;
-  loadFontsOnScriptStart: boolean;
   Continue: boolean;
-
 begin
   if (CurrScript.ScriptFile <> '') and CurrScript.GetReadOnly() then
   begin
@@ -1981,21 +2004,23 @@ begin
 
   Thread.SetPath(ScriptPath);
 
-  if selector.haspicked then
+  if (Selector.HasPicked) then
     Thread.Client.IOManager.SetTarget(Selector.LastPick);
 
-  if (not (Assigned(OCR_Fonts))) then
+  if (not SimbaSettings.Fonts.DisableLoading.GetDefValue(False)) then
   begin
-    OCR_Fonts := TMOCR.Create(Thread.Client);
-    if (DirectoryExists(SimbaSettings.Fonts.Path.Value)) then
-      OCR_Fonts.Fonts.Path := SimbaSettings.Fonts.Path.Value;
+    if (onStartup) and (SimbaSettings.Fonts.LoadOnSimbaStart.GetDefValue(True)) then // Startup of Simba, Let's load the fonts
+    begin
+      if (not (Assigned(OCR_Fonts))) then
+        InitOCR(OCR_Fonts, Thread);
+    end else
+      if (not onStartup) and (not SimbaSettings.Fonts.LoadOnSimbaStart.GetDefValue(True)) then // Script starting up, let's load them
+        if (not (Assigned(OCR_Fonts))) then
+          InitOCR(OCR_Fonts, Thread);
+
+    if (Assigned(OCR_Fonts)) then
+      Thread.SetFonts(OCR_Fonts.Fonts);
   end;
-
-  loadFontsOnScriptStart := SimbaSettings.Fonts.LoadOnScriptStart.GetDefValue(True);
-  if ((loadFontsOnScriptStart) and (DirectoryExists(SimbaSettings.Fonts.Path.Value))) then
-    OCR_Fonts.InitTOCR(SimbaSettings.Fonts.Path.Value);
-  Thread.SetFonts(OCR_Fonts.Fonts);
-
   {
     We pass the entire settings to the script; it will then create a Sandbox
     for settings that are exported to the script. This way we can access all
@@ -2772,7 +2797,7 @@ begin
     end;
   end;
 
-  InitializeTMThread(Thread);
+  InitializeTMThread(Thread, True);
   Thread.FreeOnTerminate := False;
 
   if (not (Assigned(Thread))) then
@@ -3835,16 +3860,14 @@ begin
           FormWriteln('Successfully installed the new fonts!');
           SimbaSettings.Fonts.Version.Value := LatestVersion;
 
-          if Assigned(OCR_Fonts) then
+          if (Assigned(OCR_Fonts)) then
             OCR_Fonts.Free;
 
           FormWriteln('Freeing the current fonts. Creating new ones now');
 
-          OCR_Fonts := TMOCR.Create(nil);
-          OCR_Fonts.Fonts.Path := SimbaSettings.Fonts.Path.Value;
-
           if (SimbaSettings.Fonts.LoadOnSimbaStart.GetDefValue(True)) then
-            OCR_Fonts.InitTOCR(SimbaSettings.Fonts.Path.Value);
+            if (not SimbaSettings.Fonts.DisableLoading.GetDefValue(False)) then
+              InitOCR(OCR_Fonts, nil);
         end;
         UnTarrer.Free;
         Decompress.Result.Free;

--- a/Units/MMLAddon/LPInc/Classes/miniLCL/lplclgraphics.pas
+++ b/Units/MMLAddon/LPInc/Classes/miniLCL/lplclgraphics.pas
@@ -882,6 +882,16 @@ begin
   PAntialiasingMode(Result)^ := PCanvas(Params^[0])^.AntialiasingMode;
 end;
 
+procedure TCanvas_Handle_Set(const Params: PParamArray); lape_extdecl
+begin
+  PCanvas(Params^[0])^.Handle := PPtrUInt(Params^[1])^;
+end;
+
+procedure TCanvas_Handle_Get(const Params: PParamArray; const Result: Pointer); lape_extdecl
+begin
+  PPtrUInt(Result)^ := PCanvas(Params^[0])^.Handle;
+end;
+
 procedure Register_TCanvas(Compiler: TLapeCompiler);
 begin
   with Compiler do
@@ -943,6 +953,7 @@ begin
     addClassVar('TCanvas', 'OnChange', 'TNotifyEvent', @TCanvas_OnChange_Read, @TCanvas_OnChange_Write);
     addClassVar('TCanvas', 'OnChanging', 'TNotifyEvent', @TCanvas_OnChanging_Read, @TCanvas_OnChanging_Write);
     addClassVar('TCanvas', 'AntialiasingMode', 'TAntialiasingMode', @TCanvas_AntialiasingMode_Get, @TCanvas_AntialiasingMode_Set);
+    addClassVar('TCanvas', 'Handle', 'PtrUInt', @TCanvas_Handle_Get, @TCanvas_Handle_Set);
     addGlobalFunc('procedure TCanvas.Init();', @TCanvas_Init);
     addGlobalFunc('procedure TCanvas.Free();', @TCanvas_Free);
   end;

--- a/Units/MMLCore/fontloader.pas
+++ b/Units/MMLCore/fontloader.pas
@@ -262,7 +262,8 @@ begin
 
   if FontFound then
   begin
-    TClient(Client).Writeln('Font ' + Name + ' already loaded as: ' + n);
+    if (Client <> nil) then
+      TClient(Client).Writeln('Font ' + Name + ' already loaded as: ' + n);
     Exit(False);
   end;
 
@@ -272,7 +273,6 @@ begin
     F.Name := F.Name + '_s';
   f.Data := InitOCR(LoadGlyphMasks(fontPath + DS, Shadow));
   Fonts.Add(f);
-  TClient(Client).Writeln('Loaded Font ' + f.Name);
 end;
 
 function TMFonts.LoadSystemFont(const SysFont: TFont; const FontName: string): boolean;


### PR DESCRIPTION
Fixed and tidy up font loading (was broken in this branch), changed settings slightly and exported TCanvas.Handle.

We have now have the setting 'disable loading' which will disable all font loading.
If setting 'LoadOnSimba' start is false, will load fonts when a script is compiled.

Most importantly this branch is now fully working. :)
