### PR TITLE
Fix: AverageExtended (Init Result-variable)

### DIFF
--- a/Units/MMLCore/tpa.pas
+++ b/Units/MMLCore/tpa.pas
@@ -3188,8 +3188,9 @@ function AverageExtended(const tE: TExtendedArray): Extended;
 var
   i, h: Integer;
 begin
+  Result := 0;
   h := High(tE);
-  if h < 0 then Exit(0);
+  if h < 0 then Exit;
   for i := 0 to h do
     Result := (Result + tE[i]);
   Result := Result / (H+1);  


### PR DESCRIPTION
Too used to the auto-initialization which Lape offers.
