### PR TITLE
Associate Extension Compiles - SV

### DIFF
--- a/Extensions/associate.sex
+++ b/Extensions/associate.sex
@@ -3,7 +3,7 @@ program AssociateFiles;
 //http://villavu.com/forum/showthread.php?t=56853
 
 const
-  ExtensionsDef = 'simb,simba,sex';
+  ExtensionsDef = 'simb,simba,sex,sei';
 
 var
   SimbaMenu: TMenuItem;

--- a/Extensions/associate.sex
+++ b/Extensions/associate.sex
@@ -10,7 +10,7 @@ var
   Extensions: string;
 
 type
-  {$IFNDEF SIMBAMAJOR1000}
+  {$IFNDEF SIMBAMAJOR1100}
   TCharArray = array of Char;
   {$ENDIF}
 
@@ -260,7 +260,7 @@ end;
 
 function GetVersion : string;
 begin;
-  result := '0.1';
+  result := '0.2';
 end;
 
 begin


### PR DESCRIPTION
Changes:
-Checks for Simba Major Version 1100
-Extensions Version bumped to 0.2
-".sei" files associated

Before the above changes, the extension would reportedly fail to compile according to the debug.
The extension was updated with assumption that the user is using the latest stable Simba.

Paste of error: http://paste.villavu.com/show/6512/