### PR TITLE
Fix TMufasaBitmap.SaveToFile memory leak

### DIFF
--- a/Units/MMLCore/bitmaps.pas
+++ b/Units/MMLCore/bitmaps.pas
@@ -588,21 +588,21 @@ begin
   ArrDataToRawImage(FData,Point(w,h),RawImage);
   result := true;
 
-  if RightStr(Filename, 3) = 'png' then
+  if LowerCase(RightStr(Filename, 3)) = 'png' then
   begin
     png := TPortableNetworkGraphic.Create;
-    png.LoadFromRawImage(RawImage, False);
     try
+       png.LoadFromRawImage(RawImage, False);
        png.SaveToFile(UTF8ToSys(Filename));
     except
        result := false;
     end;
     png.Free;
-  end else if (RightStr(Filename, 3) = 'jpg') or (RightStr(Filename, 4) = 'jpeg') then
+  end else if (LowerCase(RightStr(Filename, 3)) = 'jpg') or (LowerCase(RightStr(Filename, 4)) = 'jpeg') then
   begin
     jpg := TJPEGImage.Create;
-    jpg.LoadFromRawImage(RawImage, False);
     try
+       jpg.LoadFromRawImage(RawImage, False);
        jpg.SaveToFile(UTF8ToSys(Filename));
     except
        result := false;
@@ -617,7 +617,7 @@ begin
        result := false;
     end;
     Bmp.Free;
-  end;
+  end; 
 end;
 
 procedure TMufasaBitmap.LoadFromFile(const FileName: string);

--- a/Units/MMLCore/bitmaps.pas
+++ b/Units/MMLCore/bitmaps.pas
@@ -587,27 +587,36 @@ var
 begin
   ArrDataToRawImage(FData,Point(w,h),RawImage);
   result := true;
-  try
-    if RightStr(Filename, 3) = 'png' then
-    begin
-      png := TPortableNetworkGraphic.Create;
-      png.LoadFromRawImage(RawImage, False);
-      png.SaveToFile(UTF8ToSys(Filename));
-      png.Free;
-    end else if (RightStr(Filename, 3) = 'jpg') or (RightStr(Filename, 4) = 'jpeg') then
-    begin
-      jpg := TJPEGImage.Create;
-      jpg.LoadFromRawImage(RawImage, False);
-      jpg.SaveToFile(UTF8ToSys(Filename));
-      jpg.Free;
-    end else // Assume .bmp
-    begin
-      Bmp := TLazIntfImage.Create(RawImage,false);
-      Bmp.SaveToFile(UTF8ToSys(FileName));
-      Bmp.Free;
+
+  if RightStr(Filename, 3) = 'png' then
+  begin
+    png := TPortableNetworkGraphic.Create;
+    png.LoadFromRawImage(RawImage, False);
+    try
+       png.SaveToFile(UTF8ToSys(Filename));
+    except
+       result := false;
     end;
-  except
-    result := false;
+    png.Free;
+  end else if (RightStr(Filename, 3) = 'jpg') or (RightStr(Filename, 4) = 'jpeg') then
+  begin
+    jpg := TJPEGImage.Create;
+    jpg.LoadFromRawImage(RawImage, False);
+    try
+       jpg.SaveToFile(UTF8ToSys(Filename));
+    except
+       result := false;
+    end;
+    jpg.Free;
+  end else // Assume .bmp
+  begin
+    Bmp := TLazIntfImage.Create(RawImage,false);
+    try
+       Bmp.SaveToFile(UTF8ToSys(FileName));
+    except
+       result := false;
+    end;
+    Bmp.Free;
   end;
 end;
 


### PR DESCRIPTION
https://github.com/MerlijnWajer/Simba/issues/303#issuecomment-57053656
That only fixed half of the leak as there's another leak here (doesn't get freed if SaveToFile fails)