### PR TITLE
Set FPath in fontloader.pas

### DIFF
--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1916,7 +1916,6 @@ procedure TSimbaForm.InitializeTMThread(out Thread: TMThread);
 var
   ScriptPath: string;
   Script: string;
-  loadFontsOnScriptStart: boolean;
   Continue: boolean;
 
 begin
@@ -1985,16 +1984,16 @@ begin
   if selector.haspicked then
     Thread.Client.IOManager.SetTarget(Selector.LastPick);
 
-  loadFontsOnScriptStart := SimbaSettings.Fonts.LoadOnStartUp.GetDefValue(True);
-  if (loadFontsOnScriptStart) then
+  if ((not (Assigned(OCR_Fonts))) and DirectoryExists(SimbaSettings.Fonts.Path.Value)) then
   begin
-    if ((not (Assigned(OCR_Fonts))) and DirectoryExists(SimbaSettings.Fonts.Path.Value)) then
-    begin
-      OCR_Fonts := TMOCR.Create(Thread.Client);
-      OCR_Fonts.InitTOCR(SimbaSettings.Fonts.Path.Value);
-    end;
-    Thread.SetFonts(OCR_Fonts.Fonts);
+    OCR_Fonts := TMOCR.Create(Thread.Client);
+
+    if SimbaSettings.Fonts.LoadOnStartUp.Value then
+      OCR_Fonts.InitTOCR(SimbaSettings.Fonts.Path.Value)
+    else
+      OCR_Fonts.SetPath(SimbaSettings.Fonts.Path.Value);
   end;
+  Thread.SetFonts(OCR_Fonts.Fonts);
 
   {
     We pass the entire settings to the script; it will then create a Sandbox

--- a/Units/MMLCore/ocr.pas
+++ b/Units/MMLCore/ocr.pas
@@ -59,6 +59,7 @@ type
   public
     constructor Create(Owner: TObject);
     destructor Destroy; override;
+    procedure SetPath(const path: string);
     function InitTOCR(const path: string): boolean;
     function getTextPointsIn(sx, sy, w, h: Integer; shadow: boolean;
            var _chars, _shadows: T2DPointArray): Boolean;
@@ -158,6 +159,23 @@ begin
 
   Self.FFonts.Free;
   inherited Destroy;
+end;
+
+(*
+SetPath
+~~~~~~~~
+
+.. code-block:: pascal
+
+    function TMOCR.SetPath(const path: string): boolean;
+
+SetPath sets the path for FFonts
+We don't do this in the constructor because we may not yet have the path.
+
+*)
+procedure TMOCR.SetPath(const path: string);
+begin
+  FFonts.Path := path;
 end;
 
 (*


### PR DESCRIPTION
SetPath was never called so FPath in TMFonts.LoadFont was null.

Not sure if using newsimbasettings in fontloader is the optimal fix?
https://github.com/MerlijnWajer/Simba/issues/307#issuecomment-62270478
@JohnPeel 