### PR TITLE
colorpicker to clipboard feature

### DIFF
--- a/Projects/Simba/newsimbasettings.pas
+++ b/Projects/Simba/newsimbasettings.pas
@@ -229,6 +229,8 @@ type
     TColourPickerSection = class(TSection)
       AddToHistoryOnPick: TBooleanSetting;
       ShowHistoryOnPick: TBooleanSetting;
+      AddCoordinateToClipBoard: TBooleanSetting;
+      AddColourToClipBoard: TBooleanSetting;
     end;
 
     TCodeHintsSection = class(TSection)
@@ -855,6 +857,8 @@ procedure GetGeneralMaxRecentFiles(obj: TObject); begin TIntegerSetting(obj).Val
 
 procedure GetColourPickerShowHistoryonPick(obj: TObject); begin TBooleanSetting(obj).Value := True; end;
 procedure GetColourPickerAddToHistoryOnPick(obj: TObject); begin TBooleanSetting(obj).Value := True; end;
+procedure GetColourPickerAddCoordinateToClipBoard(obj: TObject); begin TBooleanSetting(obj).Value := False; end;
+procedure GetColourPickerAddColourToClipBoard(obj: TObject); begin TBooleanSetting(obj).Value := False; end;
 
 procedure GetCodeInsightShowHidden(obj: TObject); begin TBooleanSetting(obj).Value := False; end;
 procedure GetFunctionListShowOnStart(obj: TObject); begin TBooleanSetting(obj).Value := True; end;
@@ -989,6 +993,10 @@ begin
   ColourPicker.AddToHistoryOnPick.onDefault := @GetColourPickerAddToHistoryOnPick;
   ColourPicker.ShowHistoryOnPick := ColourPicker.AddChild(TBooleanSetting.Create(ssColourPickerShowHistoryOnPick)) as TBooleanSetting;
   ColourPicker.ShowHistoryOnPick.onDefault := @GetColourPickerShowHistoryonPick;
+  ColourPicker.AddCoordinateToClipBoard := ColourPicker.AddChild(TBooleanSetting.Create(ssColourPickerAddCoordinateToClipBoard)) as TBooleanSetting;
+  ColourPicker.AddCoordinateToClipBoard.onDefault := @GetColourPickerAddCoordinateToClipBoard;
+  ColourPicker.AddColourToClipBoard := ColourPicker.AddChild(TBooleanSetting.Create(ssColourPickerAddColourToClipBoard)) as TBooleanSetting;
+  ColourPicker.AddColourToClipBoard.onDefault := @GetColourPickerAddColourToClipBoard;
 
   CodeHints := AddChild(TCodeHintsSection.Create()) as TCodeHintsSection;
   CodeHints.ShowAutomatically := CodeHints.AddChild(TBooleanSetting.Create(ssCodeHintsShowAutomatically)) as TBooleanSetting;
@@ -1037,4 +1045,3 @@ end;
 
 
 end.
-

--- a/Projects/Simba/settings_const.inc
+++ b/Projects/Simba/settings_const.inc
@@ -43,7 +43,8 @@ ssTabsCheckBeforeOpen = ssSettings + ssTabs + 'CheckTabsBeforeOpen';
 
 ssColourPickerShowHistoryOnPick = ssSettings + ssColourPicker + 'ShowHistoryOnPick';
 ssColourPickerAddToHistoryOnPick = ssSettings + ssColourPicker + 'AddToHistoryOnPick';
-
+ssColourPickerAddCoordinateToClipBoard = ssSettings + ssColourPicker + 'AddCoordinateToClipBoard';
+ssColourPickerAddColourToClipBoard = ssSettings + ssColourPicker + 'AddColourToClipBoard';
 
 ssScriptsPath = ssSettings + ssScripts + 'Path';
 
@@ -88,4 +89,3 @@ ssSMURL = ssScriptManager + 'URL';
 ssSMPath = ssScriptManager + 'Path';
 ssSMFile = ssScriptManager + 'File';
 ssFRun = ssScriptManager + 'FirstRun';
-

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -3528,13 +3528,11 @@ begin
   {$ENDIF}
 end;
 
-
-
 procedure TSimbaForm.ButtonPickClick(Sender: TObject);
 var
    c, x, y: Integer;
    cobj: TColourPickerObject;
-   coordinate: String; 
+   coordinate, colour, clipboardtext: String;
 begin
   if Picker.Picking then
   begin
@@ -3551,16 +3549,28 @@ begin
   if SimbaSettings.ColourPicker.ShowHistoryOnPick.GetDefValue(True) then
     ColourHistoryForm.Show;
 
+  colour := inttostr(c);
   coordinate := inttostr(x) + ', ' + inttostr(y);
-  FormWritelnEx('Picked colour: ' + inttostr(c) + ' at (' + coordinate + ')');
+  FormWritelnEx('Picked colour: ' + colour + ' at (' + coordinate + ')');
+  if (SimbaSettings.ColourPicker.AddColourToClipBoard.GetDefValue(False)) then
+  begin
+    clipboardtext := colour;
+    if (SimbaSettings.ColourPicker.AddCoordinateToClipBoard.GetDefValue(False)) then
+      clipboardtext := clipboardtext + ', ' + coordinate;
+  end else
+    if (SimbaSettings.ColourPicker.AddCoordinateToClipBoard.GetDefValue(False)) then
+      clipboardtext := coordinate;
+
+  if clipboardtext = '' then
+    Exit;
+
   try
-    Clipboard.AsText := coordinate;
+    Clipboard.AsText := clipboardtext;
   except
     on e: exception do
       mDebugLn('Exception in TSimbaForm.ButtonPickClick: ' + e.message);
-  end; 
+  end;
 end;
-
 
 procedure TSimbaForm.ButtonSelectorDown(Sender: TObject; Button: TMouseButton;
   Shift: TShiftState; X, Y: Integer);
@@ -4274,4 +4284,3 @@ initialization
 
 
 end.
-


### PR DESCRIPTION
https://github.com/MerlijnWajer/Simba/pull/359

It can now do any of the below:
1. copy colour 
2. copy coordinate
3. copy both (format eg: 123456, 300, 400)
4. do nothing as per before (by default; both settings to false)