### PR TITLE
Fix Lape_ConvertTime64

### DIFF
--- a/Units/MMLAddon/LPInc/Wrappers/lp_other.inc
+++ b/Units/MMLAddon/LPInc/Wrappers/lp_other.inc
@@ -125,7 +125,7 @@ end;
 
 procedure Lape_ConvertTime64(const Params: PParamArray); lape_extdecl
 begin
-  ps_ConvertTime64(Pinteger(Params^[0])^, Pinteger(Params^[1])^, Pinteger(Params^[2])^, Pinteger(Params^[3])^, Pinteger(Params^[4])^, Pinteger(Params^[5])^, Pinteger(Params^[6])^, Pinteger(Params^[7])^);
+  ps_ConvertTime64(Pint64(Params^[0])^, Pinteger(Params^[1])^, Pinteger(Params^[2])^, Pinteger(Params^[3])^, Pinteger(Params^[4])^, Pinteger(Params^[5])^, Pinteger(Params^[6])^, Pinteger(Params^[7])^);
 end;
 
 procedure Lape_HakunaMatata(const Params: PParamArray); lape_extdecl


### PR DESCRIPTION
Wasn't working correctly for argument greater than 32-bit since it gets converted to 32bit