### PR TITLE
settings bug fixes

### DIFF
--- a/Projects/Simba/newsimbasettings.pas
+++ b/Projects/Simba/newsimbasettings.pas
@@ -930,7 +930,7 @@ begin
   {$IFDEF USE_EXTENSIONS}
   Extensions := AddChild(TExtensionsSection.Create()) as TExtensionsSection;
   Extensions.Path := Extensions.AddChild(TPathSetting.Create(ssExtensionsPath)) as TPathSetting;
-  {$IFDEF USE_EXTENSIONS}Extensions.Path.onDefault := @GetExtPath;{$ENDIF}
+  Extensions.Path.onDefault := @GetExtPath;
   Extensions.FileExtension := Extensions.AddChild(TStringSetting.Create(ssExtensionsFileExtension)) as TStringSetting;
   Extensions.FileExtension.onDefault := @GetExtensionsFileExtension;
   {$ENDIF}

--- a/Projects/Simba/simbasettingssimple.pas
+++ b/Projects/Simba/simbasettingssimple.pas
@@ -278,10 +278,11 @@ begin
   if (N <> nil) and (N.HasChildren) then
     N.GetLastChild.Text:= SimbaSettings.Includes.Path.Value;
 
-
+  {$IFDEF USE_EXTENSIONS}
   N := PathsTreeView.Items.FindNodeWithText('Extensions');
   if (N <> nil) and (N.HasChildren) then
     N.GetLastChild.Text:= SimbaSettings.Extensions.Path.Value;
+  {$ENDIF}
 
   N := PathsTreeView.Items.FindNodeWithText('Plugins');
   if (N <> nil) and (N.HasChildren) then

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -3698,7 +3698,7 @@ end;
 
 function TSimbaForm.GetShowCodeCompletionAuto: boolean;
 begin
-  Result := SimbaSettings.CodeHints.ShowAutomatically.GetDefValue(True);
+  Result := SimbaSettings.CodeCompletion.ShowAutomatically.GetDefValue(True);
 end;
 
 procedure TSimbaForm.SetScriptState(const State: TScriptState);

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1396,6 +1396,7 @@ begin
       end;
 
       FormWritelnEx('Script already started! Restarting script...');
+      ScriptState := ss_Stopping;
       StopScript();
     end;
     InitializeTMThread(scriptthread);


### PR DESCRIPTION
Fixed issue #304
SimbaSettings.Extensions.Path.Value is not set when USE_EXTENSIONS is
not defined, resulting in access violation error.
Also removed duplicate ifdef in newsimbasettings.pas

Corrected GetShowCodeCompletionAuto getting the wrong setting (CodeHints instead of CodeCompletion, as seen at https://github.com/riwu/Simba/blob/e1c936e00ebb81530a5a9aff498ec22f8d8e6236/Projects/Simba/simbaunit.pas#L3908)

