### PR TITLE
AddOnTerminate optional param skipIfUserTerminated

### DIFF
--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -571,7 +571,7 @@ var
   PrevWndProc : WNDPROC;
   {$endif}
   CurrentSyncInfo : TSyncInfo;//We need this for SafeCallThread
-
+  TerminatedByUser : Boolean;
 
 implementation
 uses
@@ -1399,6 +1399,7 @@ begin
       ScriptState := ss_Stopping;
       StopScript();
     end;
+    TerminatedByUser := False;
     InitializeTMThread(scriptthread);
     if (Assigned(ScriptThread)) then
     begin
@@ -2405,6 +2406,7 @@ end;
 
 procedure TSimbaForm.ActionStopExecute(Sender: TObject);
 begin
+  TerminatedByUser := True;
   Self.StopScript;
 end;
 

--- a/Units/MMLAddon/LPInc/Wrappers/lp_other.inc
+++ b/Units/MMLAddon/LPInc/Wrappers/lp_other.inc
@@ -5,7 +5,7 @@ end;
 
 procedure Lape_AddOnTerm(const Params: PParamArray; const Result: Pointer); lape_extdecl
 begin
-  PBoolean(Result)^ := ps_AddOnTerminate(PlpString(Params^[0])^);
+  PBoolean(Result)^ := ps_AddOnTerminate(PlpString(Params^[0])^, PBoolean(Params^[1])^);
 end;
 
 procedure Lape_DelOnTerm(const Params: PParamArray; const Result: Pointer); lape_extdecl

--- a/Units/MMLAddon/LPInc/lpexportedmethods.inc
+++ b/Units/MMLAddon/LPInc/lpexportedmethods.inc
@@ -24,7 +24,7 @@
 { Other }
 SetCurrSection('Other');
 //AddGlobalFunc('procedure Writeln(const str: string);', @Lape_Writeln);
-AddGlobalFunc('function AddOnTerminate(const proc: string): Boolean;', @Lape_AddOnTerm);
+AddGlobalFunc('function AddOnTerminate(const proc: string; skipIfUserTerminated: Boolean = False): Boolean;', @Lape_AddOnTerm);
 AddGlobalFunc('function DeleteOnTerminate(const proc: string): Boolean;', @Lape_DelOnTerm);
 AddGlobalFunc('function SetScriptProp(prop: TSP_Property; Value: TVariantArray): boolean', @Lape_SetScriptProp);
 AddGlobalFunc('function GetScriptProp(prop: TSP_Property; var Value: TVariantArray): boolean', @Lape_GetScriptProp);

--- a/Units/MMLAddon/PSInc/Wrappers/other.inc
+++ b/Units/MMLAddon/PSInc/Wrappers/other.inc
@@ -27,8 +27,15 @@ end;
 
 {$IFNDEF MML_EXPORT_THREADSAFE}
 function ps_SetScriptProp(prop : TSP_Property; Value: TVariantArray): boolean; extdecl;
+var
+  i: Integer;
 begin
-  Exit(CurrThread.Prop.SetProp(prop, Value));
+  Result := True;
+  if prop = SP_OnTerminate then
+    CurrThread.Prop.ClearOnTerminateProcs;
+  for i:= 0 to High(Value) do
+    if not CurrThread.Prop.AddProp(prop, Value[i]) then
+      Result := False;
 end;
 
 function ps_GetScriptProp(prop : TSP_Property; var Value : TVariantArray) : boolean; extdecl;
@@ -230,56 +237,14 @@ begin;
 end;
 
 {$DEFINE PS_ADDONTERMINATE}
-function ps_AddOnTerminate(const proc : string): Boolean; extdecl;
-var
-  oldProcs : TVariantArray;
-  oldProcsHigh, i : Integer;
-  lowerCaseProc : string;
+function ps_AddOnTerminate(const proc : string; skipIfUserTerminated: Boolean = False): Boolean; extdecl;
 begin;
-  result := false;
-
-  if not CurrThread.Prop.GetProp(SP_OnTerminate, oldProcs) then
-     SetLength(oldProcs, 1);
-
-  oldProcsHigh  := High(oldProcs);
-  lowerCaseProc := LowerCase(proc);
-
-  for i := 0 to oldProcsHigh do
-    if LowerCase(oldProcs[i]) = lowerCaseProc then
-      exit;
-
-  SetLength(oldProcs, Length(oldProcs) + 1);
-  oldProcs[High(oldProcs)] := proc;
-  CurrThread.Prop.SetProp(SP_OnTerminate, oldProcs);
-
-  result := True;
+  result := CurrThread.Prop.AddProp(SP_OnTerminate, proc, skipIfUserTerminated);
 end;
 
 function ps_DeleteOnTerminate(const Proc : string): Boolean; extdecl;
-var
-  curProcs, newProcs: TVariantArray;
-  I, C: Integer;
-  _Proc: string;
 begin;
-  Result := False;
-
-  if (not (CurrThread.Prop.GetProp(SP_OnTerminate, curProcs))) then
-     Exit;
-
-  _Proc := Lowercase(Proc);
-  SetLength(newProcs, Length(curProcs));
-
-  C := 0;
-  for I := 0 to High(curProcs) do
-    if (not (Lowercase(curProcs[I]) = _Proc)) then
-    begin
-      newProcs[C] := curProcs[I];
-      Inc(C);
-    end else
-      Result := True;
-
-  SetLength(newProcs, C);
-  Result := Result and CurrThread.Prop.SetProp(SP_OnTerminate, newProcs);
+  Result := CurrThread.Prop.DeleteOnTerminateProcs(Proc);
 end;
 
 function ps_GetTimeRunning: LongWord; extdecl;

--- a/Units/MMLAddon/mmlpsthread.pas
+++ b/Units/MMLAddon/mmlpsthread.pas
@@ -601,7 +601,8 @@ begin
   SetLength(V, 0);
   if (SP_OnTerminate in Prop.Properties) then
     for I := 0 to Prop.OnTerminateProcs.Count - 1 do
-      CallMethod(Prop.OnTerminateProcs[I], V);
+      if (not Prop.OnTerminateProcsSkip[i]) or (not TerminatedByUser) then
+        CallMethod(Prop.OnTerminateProcs[I], V);
 end;
 
 {$IFDEF USE_PASCALSCRIPT}


### PR DESCRIPTION
Added optional param skipIfUserTerminated to AddOnTerminate (Lape only) (defaults to false, as per current): proc will not be executed if script was terminated manually by user.

Improved efficiency&simplicity of adding procs by appending to the TStringList
instead of retrieving, adding to another list, clearing, then re-adding all procs.

Removed unused methods in scriptproperties.pas. (Exported methods remain
as per before so it's fully backward compatible)