### PR TITLE
Remove ssl RandScreen, added font update setting

### DIFF
--- a/Projects/Simba/newsimbasettings.pas
+++ b/Projects/Simba/newsimbasettings.pas
@@ -162,6 +162,7 @@ type
     TFontsSection = class(TSection)
       Path: TPathSetting;
       LoadOnStartUp: TBooleanSetting;
+      CheckForUpdates: TBooleanSetting;
       Version: TIntegerSetting;
       VersionLink: TStringSetting;
       UpdateLink: TStringSetting;
@@ -851,6 +852,7 @@ procedure GetInterpreterType(obj: TObject); begin TIntegerSetting(obj).Value := 
 procedure GetInterpreterAllowSysCalls(obj: TObject); begin TBooleanSetting(obj).Value := False; end;
 
 procedure GetFontsLoadOnStartUp(obj: TObject); begin TBooleanSetting(obj).Value := True; end;
+procedure GetFontsCheckForUpdates(obj: TObject); begin TBooleanSetting(obj).Value := True; end;
 procedure GetFontsVersion(obj: TObject); begin TIntegerSetting(obj).Value := -1; end;
 procedure GetFontsVersionLink(obj: TObject); begin TStringSetting(obj).Value := FontURL + 'Version'; end;
 procedure GetFontsUpdateLink(obj: TObject); begin TStringSetting(obj).Value := FontURL + 'Fonts.tar.bz2'; end;
@@ -920,6 +922,8 @@ begin
 
   Fonts.LoadOnStartUp := Fonts.AddChild(TBooleanSetting.Create(ssLoadFontsOnStart)) as TBooleanSetting;
   Fonts.LoadOnStartUp.onDefault := @GetFontsLoadOnStartUp;
+  Fonts.CheckForUpdates := Fonts.AddChild(TBooleanSetting.Create(ssFontsCheckForUpdates)) as TBooleanSetting;
+  Fonts.CheckForUpdates.onDefault := @GetFontsCheckForUpdates;
   Fonts.Version := Fonts.AddChild(TIntegerSetting.Create(ssFontsVersion)) as TIntegerSetting;
   Fonts.Version.onDefault := @GetFontsVersion;
   Fonts.VersionLink := Fonts.AddChild(TStringSetting.Create(ssFontsVersionLink)) as TStringSetting;

--- a/Projects/Simba/settings_const.inc
+++ b/Projects/Simba/settings_const.inc
@@ -29,6 +29,7 @@ ssAutomaticallyUpdate = ssSettings + ssUpdater + 'AutomaticallyUpdate';
 ssUpdaterReleaseChannel = ssSettings + ssUpdater + 'ReleaseChannel';
 
 ssLoadFontsOnStart = ssSettings + ssFonts + 'LoadOnStartUp';
+ssFontsCheckForUpdates = ssSettings + ssFonts + 'CheckForUpdates';
 ssFontsVersion = ssSettings + ssFonts + 'Version';
 ssFontsLink = ssSettings + ssFonts + 'UpdateLink';
 ssFontsVersionLink = ssSettings + ssFonts + 'VersionLink';

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1296,15 +1296,15 @@ end;
 
 procedure TSimbaForm.UpdateTimerCheck(Sender: TObject);
 var
-   chk: Boolean;
    time:integer;
   LatestVersion : integer;
 begin
   UpdateTimer.Interval := MaxInt;
-  FontUpdate;
-  chk := SimbaSettings.Updater.CheckForUpdates.GetDefValue(True);
 
-  if not chk then
+  if SimbaSettings.Fonts.CheckForUpdates.GetDefValue(True) then
+    FontUpdate;
+
+  if not SimbaSettings.Updater.CheckForUpdates.GetDefValue(True) then
     Exit;
 
   LatestVersion:= SimbaUpdateForm.GetLatestSimbaVersion;

--- a/Units/Synapse/ssl_openssl_lib.pas
+++ b/Units/Synapse/ssl_openssl_lib.pas
@@ -564,11 +564,6 @@ var
 
   [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
     SetLastError = False, CallingConvention= CallingConvention.cdecl,
-    EntryPoint =  'RAND_screen')]
-    procedure RandScreen; external;
-
-  [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
-    SetLastError = False, CallingConvention= CallingConvention.cdecl,
     EntryPoint =  'BIO_new')]
     function BioNew(b: PBIO_METHOD): PBIO; external;
 
@@ -738,7 +733,6 @@ var
   procedure ErrRemoveState(pid: integer);
   procedure OPENSSLaddallalgorithms;
   procedure CRYPTOcleanupAllExData;
-  procedure RandScreen;
   function BioNew(b: PBIO_METHOD): PBIO;
   procedure BioFreeAll(b: PBIO);
   function BioSMem: PBIO_METHOD;
@@ -845,7 +839,6 @@ type
   TErrRemoveState = procedure(pid: integer); cdecl;
   TOPENSSLaddallalgorithms = procedure; cdecl;
   TCRYPTOcleanupAllExData = procedure; cdecl;
-  TRandScreen = procedure; cdecl;
   TBioNew = function(b: PBIO_METHOD): PBIO; cdecl;
   TBioFreeAll = procedure(b: PBIO); cdecl;
   TBioSMem = function: PBIO_METHOD; cdecl;
@@ -943,7 +936,6 @@ var
   _ErrRemoveState: TErrRemoveState = nil;
   _OPENSSLaddallalgorithms: TOPENSSLaddallalgorithms = nil;
   _CRYPTOcleanupAllExData: TCRYPTOcleanupAllExData = nil;
-  _RandScreen: TRandScreen = nil;
   _BioNew: TBioNew = nil;
   _BioFreeAll: TBioFreeAll = nil;
   _BioSMem: TBioSMem = nil;
@@ -1422,12 +1414,6 @@ begin
     _CRYPTOcleanupAllExData;
 end;
 
-procedure RandScreen;
-begin
-  if InitSSLInterface and Assigned(_RandScreen) then
-    _RandScreen;
-end;
-
 function BioNew(b: PBIO_METHOD): PBIO;
 begin
   if InitSSLInterface and Assigned(_BioNew) then
@@ -1807,7 +1793,6 @@ begin
         _ErrRemoveState := GetProcAddr(SSLUtilHandle, 'ERR_remove_state');
         _OPENSSLaddallalgorithms := GetProcAddr(SSLUtilHandle, 'OPENSSL_add_all_algorithms_noconf');
         _CRYPTOcleanupAllExData := GetProcAddr(SSLUtilHandle, 'CRYPTO_cleanup_all_ex_data');
-        _RandScreen := GetProcAddr(SSLUtilHandle, 'RAND_screen');
         _BioNew := GetProcAddr(SSLUtilHandle, 'BIO_new');
         _BioFreeAll := GetProcAddr(SSLUtilHandle, 'BIO_free_all');
         _BioSMem := GetProcAddr(SSLUtilHandle, 'BIO_s_mem');
@@ -1836,7 +1821,6 @@ begin
         SslLibraryInit;
         SslLoadErrorStrings;
         OPENSSLaddallalgorithms;
-        RandScreen;
 {$ELSE}
         SetLength(s, 1024);
         x := GetModuleFilename(SSLLibHandle,PChar(s),Length(s));
@@ -1853,8 +1837,6 @@ begin
           _SslLoadErrorStrings;
         if assigned(_OPENSSLaddallalgorithms) then
           _OPENSSLaddallalgorithms;
-        if assigned(_RandScreen) then
-          _RandScreen;
         if assigned(_CRYPTOnumlocks) and assigned(_CRYPTOsetlockingcallback) then
           InitLocks;
 {$ENDIF}
@@ -1991,7 +1973,6 @@ begin
     _ErrRemoveState := nil;
     _OPENSSLaddallalgorithms := nil;
     _CRYPTOcleanupAllExData := nil;
-    _RandScreen := nil;
     _BioNew := nil;
     _BioFreeAll := nil;
     _BioSMem := nil;


### PR DESCRIPTION
Removed openssl RandScreen which causes 1-2 sec startup delay.

Adding setting for checking of font updates (defaults to true, as of current behaviour)