### PR TITLE
Fix prompt on replace

### DIFF
--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -3850,7 +3850,7 @@ object SimbaForm: TSimbaForm
     end
   end
   object dlgReplace: TReplaceDialog
-    Options = [frDown, frFindNext, frHideUpDown]
+    Options = [frDown, frFindNext, frHideUpDown, frEntireScope]
     OnFind = dlgReplaceFind
     OnReplace = dlgReplaceReplace
     left = 608

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -2696,7 +2696,7 @@ var
  end;
 
 begin
-  Y:= False;
+  Y:= not (frPromptOnReplace in dlgReplace.Options);
   SOptions:= [];
   if(frMatchCase in dlgReplace.Options)then SOptions:= [ssoMatchCase];
   if(frWholeWord in dlgReplace.Options)then SOptions+= [ssoWholeWord];


### PR DESCRIPTION
Will not prompt if 'prompt on replace' checkbox is not ticked.
Search entire file checkbox is ticked by default