### PR TITLE
Fix plugin loading for FPC 3.0

### DIFF
--- a/Units/MMLCore/libloader.pas
+++ b/Units/MMLCore/libloader.pas
@@ -65,12 +65,11 @@ implementation
 
   procedure TGenericLoader.AddPath(path: string);
   var
-    idx: integer;
     verified : string;
   begin
     verified := VerifyPath(path);
     //IDK who changed this to loading a dir, but DON'T
-    if not PluginDirs.Find(verified,idx) then
+    if PluginDirs.IndexOf(verified) = -1 then
     begin
       mDebugLn('Adding Plugin Path: ' + verified);
       PluginDirs.Add(verified);

--- a/Units/MMLCore/tpa.pas
+++ b/Units/MMLCore/tpa.pas
@@ -2567,6 +2567,7 @@ begin
   if Len <= 0 then
   begin
     writeln('EdgeFromBox: Box {X1 = ', Box.X1, ', Y1 = ', Box.Y1, ', X2 = ', Box.X2, ', Y2 = ', Box.Y2, '} is invalid');
+    SetLength(Result, 0);
     Exit;
   end;
   SetLength(Result, Len);

--- a/Units/MMLCore/tpa.pas
+++ b/Units/MMLCore/tpa.pas
@@ -2564,6 +2564,11 @@ begin
   Width := (Box.x2 - Box.x1);
   Height := (Box.y2 - Box.y1);
   Len := ((Width * 2) + (Height * 2));
+  if Len <= 0 then
+  begin
+    writeln('EdgeFromBox: Box {X1 = ', Box.X1, ', Y1 = ', Box.Y1, ', X2 = ', Box.X2, ', Y2 = ', Box.Y2, '} is invalid');
+    Exit;
+  end;
   SetLength(Result, Len);
   for I := 0 to Width do
   begin


### PR DESCRIPTION
PluginDirs is not Sorted,
http://www.freepascal.org/docs-html/rtl/classes/tstringlist.find.html
under remarks, indexOf should be used.

.Find works on unsorted list previously until
https://github.com/graemeg/freepascal/commit/89cdb946eb577129502ce1c9019c30b02a607eb3,
PluginDirs.Find() will always return false -> the same plugindir gets
added repeatedly every compile/run -> plugin found multiple times
exception raised


Also fixed EdgeFromBox runtime error if box invalid