### PR TITLE
Add travis-ci support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "PascalScript"]
 	path = Units/PascalScript
 	url = git://github.com/SRL/PascalScript.git
+[submodule "autobuild/travis-lazarus"]
+	path = autobuild/travis-lazarus
+	url = https://github.com/nielsAD/travis-lazarus.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Based on .travis.yml in `travis-lazarus` (https://github.com/nielsAD/travis-lazarus)
+
+sudo: true
+
+os:
+  - linux
+  - osx
+
+env:
+  global:
+    - WINEPREFIX=~/.winelaz
+    - DISPLAY=:99.0
+  matrix:
+    - LAZ_PKG=true   # Use the latest version from the default package manager
+    - LAZ_VER=1.0.14 # Use specific (binary) release
+    - LAZ_VER=1.2.6
+    - LAZ_VER=1.4.4
+
+matrix:
+  allow_failures:
+    - env: LAZ_PKG=true
+    - env: LAZ_VER=1.0.14
+    - env: LAZ_VER=1.2.6
+    - os: osx
+  include:
+    - os: linux
+      env: LAZ_VER=1.4.4  LAZ_WINE=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
+    - os: linux
+      env: LAZ_VER=1.4.4  LAZ_WINE=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
+
+before_install:
+    # Start virtual display server
+  - sh -e /etc/init.d/xvfb start || true
+  - sudo apt-get update && sudo apt-get install libxtst-dev libkeybinder-dev || true
+
+install:
+    # Install prerequisites (wine/fpc/lazarus)
+  - ./autobuild/travis-lazarus/.travis.install.py
+
+script:
+  - $LAZ_WINE lazbuild $LAZ_OPT ./Projects/Simba/Simba.lpi

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-This file is a stub. For more information, see http://wizzup.org/simba/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+Simba
+=====
+
+[![Build Status](https://travis-ci.org/MerlijnWajer/Simba.svg?branch=master)](https://travis-ci.org/MerlijnWajer/Simba)
+
+Simba is a program used to repeat certain (complicated) tasks. Typically these tasks involve using the mouse and keyboard. Simba is programmable, which means you can design your own logic and steps that Simba will follow, based upon certain input such a colours on the screen
+
+This file is a stub. For more information, see http://wizzup.org/simba/


### PR DESCRIPTION
Automatically test build on Linux/OSX/Wine for different Lazarus versions, but allow failures on anything but Lazarus 1.4.4 for Linux/Wine.

Make sure you enable Travis for Simba (preferably before merging this) and toggle "Build only if .travis.yml is present" in the general settings.