### PR TITLE
Code integration buffering revamp

### DIFF
--- a/Projects/Simba/framescript.pas
+++ b/Projects/Simba/framescript.pas
@@ -468,7 +468,7 @@ begin
 
         s := Copy(s, 0, DotPos - 1);
         NameList := TStringList.Create();
-        FoundItems := mp.GetTypeProcs(NameList, s); // Return items found in the type
+        FoundItems := mp.GetTypeProcs(NameList, s, True); // Return items found in the type
 
         // Loop though looking for a match from what is currently typed.
         for i := 0 to (NameList.Count - 1) do

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -855,10 +855,11 @@ begin
     try
       OnMessage := @SimbaForm.OnCCMessage;
       b.SaveToStream(ms);
-      WriteLn(LibName);
       FileName := PluginsGlob.Loaded[Index].Filename;
       Run(ms, nil, -1, True);
+      Result := True;
     except
+      Result := False;
       mDebugLn('CC ERROR: Could not parse imports for plugin: ' + LibName);
     end;
   finally

--- a/Units/MMLAddon/LPInc/Classes/lpclasshelper.pas
+++ b/Units/MMLAddon/LPInc/Classes/lpclasshelper.pas
@@ -22,7 +22,7 @@ function TLapeCompilerHelper.addNativeGlobalType(Str: lpString; AName: lpString)
 begin
   with addGlobalType(Str, '_' + AName) do
   begin
-    addGlobalType('native _' + AName, AName);
+    Result := addGlobalType('native _' + AName, AName);
     Name := '!' + AName;
   end;
 end;

--- a/Units/MMLCore/ocr.pas
+++ b/Units/MMLCore/ocr.pas
@@ -1085,11 +1085,9 @@ function TMOCR.GetTextAt(xs, ys, xe,ye, minvspacing, maxvspacing, hspacing,
 var
   TPA : TPointArray;
   STPA : T2DPointArray;
-  B : TBox;
 begin;
   SetLength(TPA, 0);
   TClient(Client).MFinder.FindColorsTolerance(TPA, color, xs,ys,xe,ye,tol);
-  b := GetTPABounds(TPA);
 
   { Split the text points into something usable. }
   { +1 because splittpa will not split well if we use 0 space ;) }

--- a/Units/MMLCore/os_windows.pas
+++ b/Units/MMLCore/os_windows.pas
@@ -564,7 +564,7 @@ end;
 
 function TIOManager.SetTarget(target: TNativeWindow): integer;
 begin
-  SetBothTargets(TWindow.Create(target));
+  Result := SetBothTargets(TWindow.Create(target));
 end;
 
 threadvar

--- a/Units/Misc/CastaliaPasLex.pas
+++ b/Units/Misc/CastaliaPasLex.pas
@@ -68,6 +68,7 @@ type
   end;
   TDefineRecArray = array of TDefineRec;
 
+  PSaveDefinesRec = ^TSaveDefinesRec;
   TSaveDefinesRec = record
     RecArray: TDefineRecArray;
     Stack: Integer;

--- a/Units/Misc/lpdump.pas
+++ b/Units/Misc/lpdump.pas
@@ -114,7 +114,11 @@ begin
   // We cannot automate getting parameter/result information for now,
   // but we can link to documentation.
   for i := 0 to InternalMethodMap.Count - 1 do
-    aItems.Add('procedure ' + InternalMethodMap.Key[i] + '(); forward;');
+    if (InternalMethodMap.Key[i] <> 'GOTO') and
+       (InternalMethodMap.Key[i] <> 'LABEL') and
+       (InternalMethodMap.Key[i] <> 'RAISE')
+    then
+      aItems.Add('procedure ' + InternalMethodMap.Key[i] + '(); forward;');
 end;
 
 end.

--- a/Units/Misc/lpdump.pas
+++ b/Units/Misc/lpdump.pas
@@ -20,7 +20,6 @@ type
 
     function addGlobalVar(AVar: TLapeGlobalVar; AName: lpString = ''): TLapeGlobalVar; override;
     function addGlobalVar(Typ: lpString; Value: lpString; AName: lpString): TLapeGlobalVar; override;
-    function addGlobalVar(Val: Int32; AName: lpString): TLapeGlobalVar; override;
     function addGlobalType(Typ: TLapeType; AName: lpString = ''; ACopy: Boolean = True): TLapeType; override;
     function addGlobalType(Str: lpString; AName: lpString): TLapeType; override;
     function addGlobalFunc(AHeader: lpString; Value: Pointer): TLapeGlobalVar; override;
@@ -33,10 +32,10 @@ implementation
 uses
   lpeval;
 
-function AddLeadingSemiColon(x: string): string;
+function AddTrailingSemiColon(x: string): string;
 begin
   Result := Trim(x);
-  if (Result[Length(Result)] <> ';') then
+  if (Result <> '') and (Result[Length(Result)] <> ';') then
     Result += ';';
 end;
 
@@ -57,43 +56,39 @@ end;
 function TLPCompiler.addGlobalVar(AVar: TLapeGlobalVar; AName: lpString = ''): TLapeGlobalVar;
 begin
   Result := inherited;
-  //if (Length(AName) > 0) and (AName[1] <> '!') then
-    //FItems.Add(AddLeadingSemiColon('const ' + AName + ' = ' + AVar.AsString));
+  if (Length(AName) > 0) and (AName[1] <> '!') and (AVar.BaseType in LapeOrdinalTypes-LapeOrdinalTypes+LapeRealTypes+LapeStringTypes+LapeSetTypes) then
+    FItems.Add('const ' + AName + ': ' + AVar.VarType.AsString + ' = ' + AVar.AsString + ';');
 end;
 
 function TLPCompiler.addGlobalVar(Typ: lpString; Value: lpString; AName: lpString): TLapeGlobalVar;
 begin
   Result := inherited;
   if (Length(AName) > 0) and (AName[1] <> '!') and (Lowercase(AName) <> Lowercase(Typ)) then
-    FItems.Add(AddLeadingSemiColon('var ' + AName + ': ' + Typ));
-end;
-
-function TLPCompiler.addGlobalVar(Val: Int32; AName: lpString): TLapeGlobalVar;
-begin
-  Result := inherited;
-  if (Length(AName) > 0) and (AName[1] <> '!') then
-    FItems.Add(AddLeadingSemiColon('var ' + AName + ': Int32 = ' + IntToStr(Val)));
+    if (Value <> '') then
+      FItems.Add('const ' + AName + ': ' + Typ + ' = ' + Value + ';')
+    else
+      FItems.Add('var ' + AName + ': ' + Typ + ';');
 end;
 
 function TLPCompiler.addGlobalType(Typ: TLapeType; AName: lpString = ''; ACopy: Boolean = True): TLapeType;
 begin
   Result := inherited;
   if (Length(AName) > 0) and (AName[1] <> '!') and (Lowercase(AName) <> Lowercase(Typ.Name)) then
-    FItems.Add(AddLeadingSemiColon('type ' + AName + ' = ' + Typ.Name));
+    FItems.Add('type ' + AName + ' = ' + Typ.Name + ';');
 end;
 
 function TLPCompiler.addGlobalType(Str: lpString; AName: lpString): TLapeType;
 begin
   Result := inherited;
   if (Length(AName) > 0) and (AName[1] <> '!') and (Lowercase(AName) <> Lowercase(Str)) then
-    FItems.Add(AddLeadingSemiColon('type ' + AName + ' = ' + Str));
+    FItems.Add('type ' + AName + ' = ' + AddTrailingSemiColon(Str));
 end;
 
 function TLPCompiler.addGlobalFunc(AHeader: lpString; Value: Pointer): TLapeGlobalVar;
 begin
   Result := inherited;
-  if (Length(Result.Name) > 0) and (Result.Name[1] <> '_') then
-    FItems.Add(AddLeadingSemiColon(AHeader) + ' forward;');
+  if (Length(Result.Name) = 0) or (Result.Name[1] <> '_') then
+    FItems.Add(AddTrailingSemiColon(AHeader) + ' forward;');
 end;
 
 function TLPCompiler.addDelayedCode(ACode: lpString; AFileName: lpString = ''; AfterCompilation: Boolean = True; IsGlobal: Boolean = True): TLapeTree_Base;

--- a/Units/Misc/v_autocompleteform.pas
+++ b/Units/Misc/v_autocompleteform.pas
@@ -674,7 +674,9 @@ begin
     exit;}
   for i := 0 to high(FParameters) do
   begin
-    if (FParameters[i] is TciConstParameter) then
+    if (FParameters[i] is TciConstRefParameter) then
+      s := 'constref '
+    else if (FParameters[i] is TciConstParameter) then
       s := 'const '
     else if (FParameters[i] is TciOutParameter) then
       s := 'out '

--- a/Units/Misc/v_autocompleteform.pas
+++ b/Units/Misc/v_autocompleteform.pas
@@ -288,9 +288,9 @@ begin
   inherited;
 
   {$IFDEF FPC}
-  if (message.Result = 0) and (Redirect <> nil) and (TLMChar(message).CharCode <> VK_DOWN) and (TLMChar(message).CharCode <> VK_UP) and (TLMChar(message).CharCode <> VK_RETURN) then
+  if (message.Result = 0) and (Redirect <> nil) and (not (TLMChar(message).CharCode in [13, 10])) then
   {$ELSE}
-  if (message.Result = 0) and (Redirect <> nil) and (TWMChar(message).CharCode <> VK_DOWN) and (TWMChar(message).CharCode <> VK_UP) and (TWMChar(message).CharCode <> VK_RETURN) then
+  if (message.Result = 0) and (Redirect <> nil) and (not (TWMChar(message).CharCode in [13, 10])) then
   {$ENDIF}
   begin
     Redirect.SetFocus;
@@ -1004,6 +1004,8 @@ begin
   FBracketPoint:= BracketPoint;
 
   CalculateBounds;  //Calculate the size we need!
+
+  FSynEdit.SetFocus();
   self.Visible := true;
 end;
 

--- a/Units/Misc/v_ideCodeInsight.pas
+++ b/Units/Misc/v_ideCodeInsight.pas
@@ -144,6 +144,7 @@ begin
   IncludeBufferCS.Acquire();
 
   try
+    Result := False;
     l := High(IncludeBuffer);
 
     for i := l downto 0 do
@@ -1583,6 +1584,7 @@ var
   dDecl: TDeclaration;
   dType: string;
 begin
+  Result := nil;
   if (Prefix = '') then
     Exit();
 

--- a/Units/Misc/v_ideCodeInsight.pas
+++ b/Units/Misc/v_ideCodeInsight.pas
@@ -314,14 +314,12 @@ begin
     if GetIncludeBuffer(Buf, LibPrefix+LibName, Age, nil) then
     begin
       AddInclude(Buf.CodeInsight);
-      Exit;
+      Exit(True);
     end;
 
     s := LibName;
     if Assigned(OnLoadLibrary) and OnLoadLibrary(Self, s, ci) and (ci <> nil) then
     begin
-      LibName := s;
-
       with Buf do
       begin
         LastChanged := Age;

--- a/Units/Misc/v_ideCodeInsight.pas
+++ b/Units/Misc/v_ideCodeInsight.pas
@@ -75,7 +75,7 @@ type
 
     procedure Proposal_AddDeclaration(Item: TDeclaration; ItemList, InsertList: TStrings; ShowTypeMethods: Boolean = False);
     procedure GetProcedures(Headers, Names: TStrings; FindTypeProcs: Boolean = False);
-    function GetTypeProcs(Names: TStrings; const Prefix: string): TDeclarationArray;
+    function GetTypeProcs(Names: TStrings; const Prefix: string; WithParams: Boolean): TDeclarationArray;
     function FindProcedure(ProcNameToFind: string; out Decl: TDeclaration; out HasParams: Boolean): boolean;
     procedure FillProposal;
     procedure FillSynCompletionProposal(ItemList, InsertList: TStrings; Prefix: string = '');
@@ -1519,7 +1519,7 @@ end;
  * var bmp: TMufasaBitmap
  * FoundItems := ci.GetTypeProcs(NamesList, 'bmp');
 *)
-function TCodeInsight.GetTypeProcs(Names: TStrings; const Prefix: string): TDeclarationArray;
+function TCodeInsight.GetTypeProcs(Names: TStrings; const Prefix: string; WithParams: Boolean): TDeclarationArray;
 
   // Returns Info of the proc. ie: Foo(var: string);
   function GetInfo(Item: TDeclaration): string;
@@ -1531,7 +1531,7 @@ function TCodeInsight.GetTypeProcs(Names: TStrings; const Prefix: string): TDecl
       ProcItem := TCIProcedureDeclaration(Item);
       Result := ProcItem.Name.CleanText;
 
-      if (ProcItem.Params <> '') then  // has params
+      if WithParams and (ProcItem.Params <> '') then  // has params
         Result += '(' + ProcItem.Params + ')';
     end;
   end;
@@ -1794,7 +1794,7 @@ begin
           NamesList := TStringList.Create();
 
           try
-            FoundItems := Self.GetTypeProcs(NamesList, TypeStr);
+            FoundItems := Self.GetTypeProcs(NamesList, TypeStr, False);
 
             for i := 0 to (NamesList.Count - 1) do
               if (SameText(NamesList[i], Prefix)) then

--- a/Units/Misc/v_ideCodeParser.pas
+++ b/Units/Misc/v_ideCodeParser.pas
@@ -526,24 +526,24 @@ function TDeclaration.GetCleanText: string;
 var
   i: Integer;
   a: TDeclarationArray;
+  s: string;
 begin
-  Result := '';
-  if (fCleanText <> '') then
-    Result := fCleanText
-  else if (fStartPos <> fEndPos) and (fOrigin <> nil) then
+  if (fCleanText = '') and (fStartPos <> fEndPos) and (fOrigin <> nil) then
   begin
-    fCleanText := RawText;
+    s := RawText;
     a := Items.GetItemsOfClass(TciJunk, True);
     for i := High(a) downto 0 do
     begin
-      Delete(fCleanText, a[i].StartPos - fStartPos + 1, a[i].EndPos - a[i].StartPos);
+      Delete(s, a[i].StartPos - fStartPos + 1, a[i].EndPos - a[i].StartPos);
       if (Pos(LineEnding, a[i].GetRawText) > 0) then
-        Insert(LineEnding, fCleanText, a[i].StartPos - fStartPos + 1)
+        Insert(LineEnding, s, a[i].StartPos - fStartPos + 1)
       else
-        Insert(' ', fCleanText, a[i].StartPos - fStartPos + 1);
+        Insert(' ', s, a[i].StartPos - fStartPos + 1);
     end;
-    Result := fCleanText;
+    fCleanText := s;
   end;
+
+  Result := fCleanText;
 end;
 
 function TDeclaration.GetShortText: string;
@@ -739,15 +739,17 @@ end;
 function TciParentedStruct.GetShortText: string;
 var
   P: LongInt;
+  s: string;
 begin
   if (fShortText = '') then
   begin
-    fShortText := CleanText;
-    P := Pos(')', fShortText);
+    s := CleanText;
+    P := Pos(')', s);
     if (P > 0) then
-      fShortText := Copy(fShortText, 1, P)
+      s := Copy(s, 1, P)
     else
-      fShortText := GetFirstWord(fShortText);
+      s := GetFirstWord(s);
+    fShortText := s;
   end;
   Result := fShortText;
 end;
@@ -887,20 +889,20 @@ function TciProcedureDeclaration.GetParams: string;
 var
   i: Integer;
   a: TDeclarationArray;
+  s: string;
 begin
-  Result := '';
-  if (fParams <> '') then
-    Result := fParams
-  else if (fItems.Count > 0) then
+  if (fParams = '') and (fItems.Count > 0) then
   begin
     a := GetParamDeclarations;
+    s := '';
     for i := Low(a) to High(a) do
-      if (fParams <> '') then
-        fParams := fParams + '; ' + a[i].ShortText
+      if (s <> '') then
+        s := s + '; ' + a[i].ShortText
       else
-        fParams := fParams + a[i].ShortText;
-    Result := fParams;
+        s := s + a[i].ShortText;
+    fParams := s;
   end;
+  Result := fParams;
 end;
 
 function TciProcedureDeclaration.GetShortText: string;


### PR DESCRIPTION
Previously, multiple threads had access to IncludeBuffer; the critical
sections weren't doing anything. Removal from the Buffer caused
invalid references on other threads or in nested includes.

I have decided to maintain one buffer instead of thread local instances.
To maintain consistency, there's 1 critical section. This means that
only one thread can parse an include at a time (but other threads
can reuse the buffer afterwards).

To main consistency for nested includes, TCodeInsight now has a ref
counter. For external code, nothing changes. For CI code, make sure
to use DecRef() instead of Free() and call AddRef() when adding a
reference.

Includes are purged from the cache when not used frequently or
whenever the include file is touched (file age does not check
recursively yet).

Should fix #309.