### PR TITLE
Fix Simba spawning off screen & change loading fonts buffer.

### DIFF
--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -1,13 +1,13 @@
 object SimbaForm: TSimbaForm
-  Left = -905
-  Height = 684
-  Top = 215
-  Width = 738
+  Left = 265
+  Height = 700
+  Top = 254
+  Width = 900
   ActiveControl = ScriptPanel
   AllowDropFiles = True
   Caption = 'Simba'
-  ClientHeight = 664
-  ClientWidth = 738
+  ClientHeight = 680
+  ClientWidth = 900
   KeyPreview = True
   Menu = MainMenu
   OnClose = FormClose
@@ -16,13 +16,14 @@ object SimbaForm: TSimbaForm
   OnDropFiles = FormDropFiles
   OnHide = doOnHide
   OnShortCut = FormShortCuts
+  Position = poScreenCenter
   LCLVersion = '1.8.2.0'
   Visible = True
   object ToolBar1: TToolBar
     Left = 0
     Height = 24
     Top = 0
-    Width = 738
+    Width = 900
     AutoSize = True
     Caption = 'ToolBar1'
     Images = Mufasa_Image_List
@@ -235,8 +236,8 @@ object SimbaForm: TSimbaForm
   object StatusBar: TStatusBar
     Left = 0
     Height = 23
-    Top = 641
-    Width = 738
+    Top = 657
+    Width = 900
     Panels = <    
       item
         Width = 60
@@ -257,17 +258,17 @@ object SimbaForm: TSimbaForm
   object PanelMemo: TPanel
     Left = 0
     Height = 154
-    Top = 487
-    Width = 738
+    Top = 503
+    Width = 900
     Align = alBottom
     ClientHeight = 154
-    ClientWidth = 738
+    ClientWidth = 900
     TabOrder = 2
     object DebugMemo: TMemo
       Left = 1
       Height = 152
       Top = 1
-      Width = 736
+      Width = 898
       Align = alClient
       Font.Height = -13
       Font.Name = 'Courier New'
@@ -281,29 +282,29 @@ object SimbaForm: TSimbaForm
     Cursor = crVSplit
     Left = 0
     Height = 5
-    Top = 482
-    Width = 738
+    Top = 498
+    Width = 900
     Align = alBottom
     ResizeAnchor = akBottom
   end
   object ScriptPanel: TPanel
     Left = 0
-    Height = 458
+    Height = 474
     Top = 24
-    Width = 738
+    Width = 900
     Align = alClient
     BevelOuter = bvNone
-    ClientHeight = 458
-    ClientWidth = 738
+    ClientHeight = 474
+    ClientWidth = 900
     DockSite = True
     TabOrder = 4
     OnDockDrop = ScriptPanelDockDrop
     OnDockOver = ScriptPanelDockOver
     object PageControl1: TPageControl
       Left = 180
-      Height = 423
+      Height = 439
       Top = 0
-      Width = 403
+      Width = 565
       Align = alClient
       Images = Mufasa_Image_List
       PopupMenu = TabPopup
@@ -319,12 +320,12 @@ object SimbaForm: TSimbaForm
     object SearchPanel: TPanel
       Left = 0
       Height = 35
-      Top = 423
-      Width = 738
+      Top = 439
+      Width = 900
       Align = alBottom
       BevelOuter = bvSpace
       ClientHeight = 35
-      ClientWidth = 738
+      ClientWidth = 900
       TabOrder = 1
       Visible = False
       object SpeedButtonSearch: TSpeedButton
@@ -463,21 +464,21 @@ object SimbaForm: TSimbaForm
     end
     object SplitterFunctionList: TSplitter
       Left = 175
-      Height = 423
+      Height = 439
       Top = 0
       Width = 5
       OnCanResize = SplitterFunctionListCanResize
       Visible = False
     end
     inline frmFunctionList: TFunctionListFrame
-      Height = 423
+      Height = 439
       Width = 175
-      ClientHeight = 423
+      ClientHeight = 439
       ClientWidth = 175
       OnEndDock = nil
       TabOrder = 3
       inherited FunctionList: TTreeView
-        Height = 378
+        Height = 394
         Width = 175
         HideSelection = True
         Images = nil
@@ -496,7 +497,7 @@ object SimbaForm: TSimbaForm
         Left = 186
       end
       inherited Panel1: TPanel
-        Top = 397
+        Top = 413
         Width = 175
         ClientWidth = 175
         inherited ClearSearch: TSpeedButton
@@ -588,8 +589,8 @@ object SimbaForm: TSimbaForm
       end
     end
     object NotesMemo: TMemo
-      Left = 588
-      Height = 423
+      Left = 750
+      Height = 439
       Top = 0
       Width = 150
       Align = alRight
@@ -599,8 +600,8 @@ object SimbaForm: TSimbaForm
       WordWrap = False
     end
     object NotesSplitter: TSplitter
-      Left = 583
-      Height = 423
+      Left = 745
+      Height = 439
       Top = 0
       Width = 5
       Align = alRight

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1475,54 +1475,43 @@ end;
 { Load settings }
 procedure TSimbaForm.LoadFormSettings;
 var
-  str: string;
-  Data : TStringArray;
-  i,ii : integer;
+  Str: String;
+  Data: TStringArray;
+  i: Int32;
 begin
-  self.BeginFormUpdate;
-  str := SimbaSettings.LastConfig.MainForm.Position.GetDefValue('');
-  if str <> '' then
-  begin;
-    Data := Explode(':',str);
-    if length(Data) <> 4 then
-      Exit;
-    Self.Left:= StrToIntDef(Data[0],Self.Left);
-    Self.Top:= StrToIntDef(Data[1],self.top);
-    Self.Width:= StrToIntDef(Data[2],self.width);
-    Self.Height:= StrToIntDef(Data[3],self.height);
+  Data := Explode(':', SimbaSettings.LastConfig.MainForm.Position.GetDefValue(''));
+  if (Length(Data) = 4) then
+  begin
+    Position := poDesigned;
+
+    SetBounds(StrToInt(Data[0]), StrToInt(Data[1]), StrToInt(Data[2]), StrToInt(Data[3]));
   end;
-  str := lowercase(SimbaSettings.LastConfig.MainForm.State.GetDefValue('normal'));
-  if str = 'maximized' then
-    self.windowstate := wsMaximized
+
+  Str := LowerCase(SimbaSettings.LastConfig.MainForm.State.GetDefValue('normal'));
+  if (Str = 'maximized') then
+    Self.WindowState := wsMaximized
   else
     Self.WindowState := wsNormal;
+
   if SettingExists(ssRecentFilesCount) then
-  begin;
-    ii := StrToIntDef(LoadSettingDef(ssRecentFilesCount, '-1'), -1);
-    for i := 0 to ii do
+    for i := 0 to StrToIntDef(LoadSettingDef(ssRecentFilesCount, '-1'), -1) do
     begin
-      str := LoadSettingDef(ssRecentFileN + inttostr(I),'');
-      if str <> '' then
-        AddRecentFile(str);
+      Str := LoadSettingDef(ssRecentFileN + IntToStr(i), '');
+      if (Str <> '') then
+        AddRecentFile(Str);
     end;
-  end;
 
   if SimbaSettings.CodeInsight.FunctionList.ShowOnStart.GetDefValue(True) or SimbaSettings.LastConfig.MainForm.FunctionListShown.GetDefValue(True) then
     FunctionListShown(True)
   else
-    FunctionListShown(false);
+    FunctionListShown(False);
 
-  {$ifdef MSWindows}
+  {$IFDEF WINDOWS}
   ShowConsole(SimbaSettings.LastConfig.MainForm.ConsoleVisible.GetDefValue(True));
-  {$endif}
+  {$ENDIF}
 
   if not SimbaSettings.Tray.AlwaysVisible.GetDefValue(True) then
-  begin
-    MTrayIcon.Hide;
-    Writeln('Hiding tray.'); // TODO REMOVE?
-  end;
-
-  self.EndFormUpdate;
+    MTrayIcon.Hide();
 end;
 
 { Save Settings }

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -55,7 +55,7 @@ uses
   SynExportHTML, SynEditKeyCmds, SynEditHighlighter,
   SynEditMarkupHighAll, SynHighlighterPas, LMessages, Buttons,
   mmisc, stringutil,mufasatypesutil,
-  about, framefunctionlist, ocr, updateform, Simbasettingsold,
+  about, framefunctionlist, fontloader, updateform, Simbasettingsold,
   Simbasettingssimple,
   v_ideCodeInsight, v_ideCodeParser, CastaliaPasLexTypes, // Code completion units
   CastaliaSimplePasPar, v_AutoCompleteForm,  // Code completion units
@@ -459,24 +459,24 @@ type
     function CreateSetting(const Key, Value : string) : string;
     procedure SetSetting(const key,Value : string; save : boolean = false);
     function SettingExists(const key : string) : boolean;
-    procedure FontUpdate;
     procedure InitializeCoreBuffer;
     procedure CustomExceptionHandler(Sender: TObject; E: Exception);
     procedure RegisterSettingsOnChanges;
+    procedure LoadFonts;
   public
     { Required to work around using freed resources on quit }
     Exiting: Boolean;
 
     DebugStream: String;
     SearchString : string;
-    CurrScript : TScriptFrame; //The current scriptframe
-    CurrTab    : TMufasaTab; //The current TMufasaTab
+    CurrScript: TScriptFrame; //The current scriptframe
+    CurrTab: TMufasaTab; //The current TMufasaTab
     CodeCompletionForm: TAutoCompletePopup;
     CodeCompletionStart: TPoint;
     ParamHint : TParamHint;
-    Tabs : TList;
+    Tabs: TList;
     Manager: TIOManager;
-    OCR_Fonts: TMOCR;
+    Fonts: TMFonts;
     Picker: TMColorPicker;
     Selector: TMWindowSelector;
     OnScriptStart : TScriptStartEvent;
@@ -784,7 +784,8 @@ begin
   Result := FindFile(Filename, [AppPath, SimbaSettings.Includes.Path.Value]);
 end;
 
-function TSimbaForm.OnCCLoadLibrary(Sender: TObject; var Argument: String; out Parser: TCodeInsight): Boolean;
+function TSimbaForm.OnCCLoadLibrary(Sender: TObject; var Argument: string; out
+  Parser: TCodeInsight): Boolean;
 var
   Dump: String;
   Plugin: TMPlugin;
@@ -1074,9 +1075,6 @@ var
   LatestVersion : integer;
 begin
   UpdateTimer.Interval := MaxInt;
-
-  if SimbaSettings.Fonts.CheckForUpdates.GetDefValue(True) then
-    FontUpdate;
 
   if not SimbaSettings.Updater.CheckForUpdates.GetDefValue(True) then
     Exit;
@@ -1593,10 +1591,10 @@ begin
       Exit;
   end;
 
-  CurrScript.ScriptErrorLine := -1;
+  LoadFonts();
 
   try
-    Thread := TMMLScriptThread.Create(Script, CurrScript.ScriptFile, SimbaSettings.MMLSettings);
+    Thread := TMMLScriptThread.Create(Script, CurrScript.ScriptFile);
     Thread.Output := DebugMemo.Lines;
     Thread.Error.Data := @CurrScript.ErrorData;
     Thread.Error.Callback := @CurrScript.HandleErrorData;
@@ -1612,10 +1610,11 @@ begin
     if Selector.HasPicked then
       Thread.Client.IOManager.SetTarget(Selector.LastPick);
 
-    // Add PluginPath
-    // Load OCR
+    Thread.CreateFonts(Fonts);
+    Thread.CreateSettings(SimbaSettings.MMLSettings);
 
     CurrScript.ScriptThreadHandle := Thread.Handle;
+    CurrScript.ScriptErrorLine := -1;
   except
     on e: Exception do
       formWriteln('Failed to initialise script thread: ' + e.ClassName + '::' + e.Message);
@@ -2649,14 +2648,8 @@ begin
     FreeAndNil(Picker);
   if (Assigned(Manager)) then
     FreeAndNil(Manager);
-   {
-  { Free the plugins }
-  if (Assigned(PluginsGlob)) then
-    FreeAndNil(PluginsGlob);
-  }
-  { Free Fonts }
-  if (Assigned(OCR_Fonts)) then
-    FreeAndNil(OCR_Fonts);
+  if Assigned(Fonts) then
+    FreeAndNil(Fonts);
 
   SetLength(DebugStream, 0);
   if (Assigned(DebugCriticalSection)) then
@@ -3280,80 +3273,22 @@ begin
   SimbaSettings.SourceEditor.Font.onChange := @SetSourceEditorFont;
 end;
 
-
-procedure TSimbaForm.FontUpdate;
-  function Idler: boolean;
-  begin
-    result := false;
-    Application.ProcessMessages;
-    Sleep(25);
-    if exiting then
-    begin
-      writeln('FontUpdate, exiting=True; breaking...');
-      result := true;
-    end;
-  end;
-
+procedure TSimbaForm.LoadFonts;
 var
-  CurrVersion : integer;
-  LatestVersion : integer;
-  FontDownload : TDownloadThread;
-  Stream : TStringStream;
-  UnTarrer : TUntarThread;
-  Fonts : string;
-  Decompress : TDecompressThread;
+  Directory: String;
 begin
-  if UpdatingFonts then
-    exit;
-  UpdatingFonts := True;
+  if (Fonts = nil) then
+  begin
+    formWritelnEx('Loading fonts...');
 
-  CurrVersion := SimbaSettings.Fonts.Version.GetDefValue(-1);
-  LatestVersion := SimbaUpdateForm.GetLatestFontVersion;
-  if LatestVersion > CurrVersion then
-  begin;
-    formWriteln(format('New fonts available. Current version: %d. Latest version: %d',[CurrVersion,LatestVersion]));
-    FontDownload := TDownloadThread.Create(SimbaSettings.Fonts.UpdateLink.GetDefValue(FontURL + 'Fonts.tar.bz2'),
-                                           @Fonts);
-    FontDownload.Start;
-    while FontDownload.Done = false do
-      if Idler then
-      begin
-        writeln('FontUpdate: Pre-mature exit due to exiting=true');
-        exit;
-      end;
-    //Fontdownload is freed now
-    Stream := TStringStream.Create(Fonts);
-    try
-      Decompress := TDecompressThread.Create(Stream);
-      Decompress.Start;
-      while Decompress.Finished = false do
-        Idler;
-      if Decompress.Result <> nil then
-      begin;
-        UnTarrer := TUntarThread.Create(Decompress.Result,
-            SimbaSettings.Fonts.Path.Value, True);
-        UnTarrer.Start;
-        while UnTarrer.Finished = false do
-          Idler;
-        if UnTarrer.Result then
-        begin;
-          FormWriteln('Successfully installed the new fonts!');
-          SimbaSettings.Fonts.Version.Value := LatestVersion;
-          if Assigned(self.OCR_Fonts) then
-            self.OCR_Fonts.Free;
-          FormWriteln('Freeing the current fonts. Creating new ones now');
-          Self.OCR_Fonts := TMOCR.Create(nil);
-          OCR_Fonts.InitTOCR(SimbaSettings.Fonts.Path.Value);
-        end;
-        UnTarrer.Free;
-        Decompress.Result.Free;
-      end;
-      Decompress.free;
-    finally
-      Stream.Free;
-    end;
+    Fonts := TMFonts.Create(nil);
+    Fonts.Path := SimbaSettings.Fonts.Path.Value;
+
+    for Directory in GetDirectories(SimbaSettings.Fonts.Path.Value) do
+      Fonts.LoadFont(Directory, False);
+
+    formWriteLn('Loaded ' + IntToStr(Fonts.Count) + ' fonts');
   end;
-  UpdatingFonts := False;
 end;
 
 procedure TSimbaForm.ScriptStartEvent(Sender: TObject; var Script: string;

--- a/Units/MMLAddon/script_thread.pas
+++ b/Units/MMLAddon/script_thread.pas
@@ -7,7 +7,7 @@ interface
 uses
   Classes, SysUtils,
   lpparser, lpcompiler, lptypes, lpvartypes, lpmessages, lpinterpreter,
-  Client, Settings, SettingsSandbox, Files;
+  Client, Settings, SettingsSandbox, Files, FontLoader;
 
 type
   PErrorData = ^TErrorData;

--- a/Units/MMLAddon/script_thread.pas
+++ b/Units/MMLAddon/script_thread.pas
@@ -60,7 +60,10 @@ type
     property Settings: TMMLSettingsSandbox read FSettings;
     property StartTime: UInt64 read FStartTime;
 
-    constructor Create(constref Script, FilePath: String; ASettings: TMMLSettings);
+    procedure CreateSettings(From: TMMLSettings);
+    procedure CreateFonts(From: TMFonts);
+
+    constructor Create(constref Script, FilePath: String);
     destructor Destroy; override;
   end;
 
@@ -236,7 +239,7 @@ begin
   end;
 end;
 
-constructor TMMLScriptThread.Create(constref Script, FilePath: String; ASettings: TMMLSettings);
+constructor TMMLScriptThread.Create(constref Script, FilePath: String);
 begin
   inherited Create(True);
 
@@ -249,9 +252,6 @@ begin
 
   FClient := TClient.Create();
   FClient.WriteLnProc := @Self.WriteLn;
-
-  FSettings := TMMLSettingsSandbox.Create(ASettings);
-  FSettings.Prefix := 'Scripts/';
 
   FOutput := nil;
   FOutputBuffer := '';
@@ -283,6 +283,24 @@ procedure TMMLScriptThread.WriteLn(constref S: String);
 begin
   Write(S);
   WriteLn();
+end;
+
+procedure TMMLScriptThread.CreateSettings(From: TMMLSettings);
+begin
+  FSettings := TMMLSettingsSandbox.Create(From);
+  FSettings.Prefix := 'Scripts/';
+end;
+
+procedure TMMLScriptThread.CreateFonts(From: TMFonts);
+var
+  i: Int32;
+begin
+  with FClient do
+  begin
+    MOCR.Fonts := From;
+    for i := 0 to MOCR.Fonts.Count - 1 do
+      FCompiler.addGlobalVar(MOCR.Fonts[i].Name, MOCR.Fonts[i].Name).isConstant := True;
+  end;
 end;
 
 end.


### PR DESCRIPTION
- Simba will now spawn in the center of the screen if no settings.xml exists (such as first launch) previously it would be where it was designed in Lazarus which could be off screen for other users.
- Loading the fonts buffer is now done when a script is first compiled (takes two seconds, one time thing) there was previously a setting to enable this. It guarantees the fonts are correctly loaded and removes any other weird sync issues we previously ran into.
- Removed the font updater, packages will replace this.