### PR TITLE
Plugin unloading and new exports.

### DIFF
--- a/Projects/Simba/Simba.lpi
+++ b/Projects/Simba/Simba.lpi
@@ -89,7 +89,7 @@
         <PackageName Value="LCL"/>
       </Item3>
     </RequiredPackages>
-    <Units Count="67">
+    <Units Count="66">
       <Unit0>
         <Filename Value="Simba.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -384,17 +384,9 @@
         <IsPartOfProject Value="True"/>
       </Unit64>
       <Unit65>
-        <Filename Value="../ACA/aca.pas"/>
+        <Filename Value="../../Units/MMLAddon/script_plugins_exports.pas"/>
         <IsPartOfProject Value="True"/>
-        <ComponentName Value="ACAForm"/>
-        <HasResources Value="True"/>
-        <ResourceBaseClass Value="Form"/>
-        <UnitName Value="ACA"/>
       </Unit65>
-      <Unit66>
-        <Filename Value="../ACA/aca_math.pas"/>
-        <IsPartOfProject Value="True"/>
-      </Unit66>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/Projects/Simba/Simba.lpr
+++ b/Projects/Simba/Simba.lpr
@@ -33,7 +33,8 @@ uses
   cthreads, cmem, linux_startup,
   {$ENDIF}
   Interfaces, Forms,
-  simbaunit, colourhistory, about, debugimage, bitmapconv, updateform, simbasettingssimple, simbasettingsold,
+  simbaunit, colourhistory, about, debugimage, bitmapconv, updateform,
+  simbasettingssimple, simbasettingsold,
   {$IFDEF USE_FORMDESIGNER}
   design_frm, frmdesigner,
   {$ENDIF}

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -1,12 +1,12 @@
 object SimbaForm: TSimbaForm
-  Left = 49
-  Height = 800
-  Top = 84
+  Left = 402
+  Height = 773
+  Top = 115
   Width = 1200
   ActiveControl = ScriptPanel
   AllowDropFiles = True
   Caption = 'Simba'
-  ClientHeight = 800
+  ClientHeight = 753
   ClientWidth = 1200
   KeyPreview = True
   Menu = MainMenu
@@ -19,13 +19,13 @@ object SimbaForm: TSimbaForm
   Position = poScreenCenter
   LCLVersion = '1.8.2.0'
   Visible = True
-  object ToolBar1: TToolBar
+  object ToolBar: TToolBar
     Left = 0
     Height = 24
     Top = 0
     Width = 1200
     AutoSize = True
-    Caption = 'ToolBar1'
+    Caption = 'ToolBar'
     Images = Mufasa_Image_List
     ParentShowHint = False
     ShowHint = True
@@ -242,8 +242,8 @@ object SimbaForm: TSimbaForm
   end
   object StatusBar: TStatusBar
     Left = 0
-    Height = 21
-    Top = 779
+    Height = 23
+    Top = 730
     Width = 1200
     Panels = <    
       item
@@ -265,7 +265,7 @@ object SimbaForm: TSimbaForm
   object PanelMemo: TPanel
     Left = 0
     Height = 154
-    Top = 625
+    Top = 576
     Width = 1200
     Align = alBottom
     ClientHeight = 154
@@ -290,19 +290,19 @@ object SimbaForm: TSimbaForm
     Cursor = crVSplit
     Left = 0
     Height = 5
-    Top = 620
+    Top = 571
     Width = 1200
     Align = alBottom
     ResizeAnchor = akBottom
   end
   object ScriptPanel: TPanel
     Left = 0
-    Height = 596
+    Height = 547
     Top = 24
     Width = 1200
     Align = alClient
     BevelOuter = bvNone
-    ClientHeight = 596
+    ClientHeight = 547
     ClientWidth = 1200
     DockSite = True
     TabOrder = 4
@@ -310,7 +310,7 @@ object SimbaForm: TSimbaForm
     OnDockOver = ScriptPanelDockOver
     object PageControl1: TPageControl
       Left = 230
-      Height = 561
+      Height = 512
       Top = 0
       Width = 740
       Align = alClient
@@ -330,7 +330,7 @@ object SimbaForm: TSimbaForm
     object SearchPanel: TPanel
       Left = 0
       Height = 35
-      Top = 561
+      Top = 512
       Width = 1200
       Align = alBottom
       BevelOuter = bvSpace
@@ -424,7 +424,7 @@ object SimbaForm: TSimbaForm
       end
       object LabeledEditSearch: TLabeledEdit
         Left = 79
-        Height = 27
+        Height = 23
         Top = 8
         Width = 248
         EditLabel.AnchorSideTop.Control = LabeledEditSearch
@@ -432,10 +432,10 @@ object SimbaForm: TSimbaForm
         EditLabel.AnchorSideRight.Control = LabeledEditSearch
         EditLabel.AnchorSideBottom.Control = LabeledEditSearch
         EditLabel.AnchorSideBottom.Side = asrBottom
-        EditLabel.Left = 39
-        EditLabel.Height = 17
-        EditLabel.Top = 13
-        EditLabel.Width = 37
+        EditLabel.Left = 47
+        EditLabel.Height = 15
+        EditLabel.Top = 12
+        EditLabel.Width = 29
         EditLabel.Caption = 'Find: '
         EditLabel.ParentColor = False
         LabelPosition = lpLeft
@@ -448,9 +448,9 @@ object SimbaForm: TSimbaForm
       end
       object CheckBoxMatchCase: TCheckBox
         Left = 398
-        Height = 24
+        Height = 19
         Top = 10
-        Width = 102
+        Width = 80
         Caption = 'Match case'
         OnClick = CheckBoxMatchCaseClick
         TabOrder = 1
@@ -474,7 +474,7 @@ object SimbaForm: TSimbaForm
     end
     object SplitterFunctionList: TSplitter
       Left = 225
-      Height = 561
+      Height = 512
       Top = 0
       Width = 5
       OnCanResize = SplitterFunctionListCanResize
@@ -482,7 +482,7 @@ object SimbaForm: TSimbaForm
     end
     object NotesSplitter: TSplitter
       Left = 970
-      Height = 561
+      Height = 512
       Top = 0
       Width = 5
       Align = alRight
@@ -492,7 +492,7 @@ object SimbaForm: TSimbaForm
     object PanelUtilites: TPairSplitter
       Cursor = crVSplit
       Left = 975
-      Height = 561
+      Height = 512
       Top = 0
       Width = 225
       Align = alRight
@@ -508,7 +508,7 @@ object SimbaForm: TSimbaForm
         ClientHeight = 350
         object lblFileBrowser: TLabel
           Left = 2
-          Height = 17
+          Height = 15
           Top = 2
           Width = 221
           Align = alTop
@@ -521,8 +521,8 @@ object SimbaForm: TSimbaForm
         end
         object FileBrowser: TShellTreeView
           Left = 0
-          Height = 329
-          Top = 21
+          Height = 331
+          Top = 19
           Width = 225
           Align = alClient
           FileSortType = fstNone
@@ -543,7 +543,7 @@ object SimbaForm: TSimbaForm
           AnchorSideBottom.Control = lblFileBrowser
           AnchorSideBottom.Side = asrBottom
           Left = -2
-          Height = 18
+          Height = 16
           Hint = 'Refresh File Browser'
           Top = 1
           Width = 16
@@ -566,14 +566,14 @@ object SimbaForm: TSimbaForm
       object PanelNotes: TPairSplitterSide
         Cursor = crArrow
         Left = 0
-        Height = 206
+        Height = 157
         Top = 355
         Width = 225
         ClientWidth = 225
-        ClientHeight = 206
+        ClientHeight = 157
         object lblNotes: TLabel
           Left = 2
-          Height = 17
+          Height = 15
           Top = 2
           Width = 221
           Align = alTop
@@ -586,8 +586,8 @@ object SimbaForm: TSimbaForm
         end
         object memoNotes: TMemo
           Left = 0
-          Height = 185
-          Top = 21
+          Height = 138
+          Top = 19
           Width = 225
           Align = alClient
           BorderStyle = bsNone
@@ -596,19 +596,14 @@ object SimbaForm: TSimbaForm
       end
     end
     inline FunctionList: TFunctionList_Frame
-      Height = 561
-      ClientHeight = 561
+      Height = 512
+      ClientHeight = 512
       TabOrder = 5
-      inherited FunctionListLabel: TLabel
-        Height = 17
-      end
       inherited Filter: TTreeFilterEdit
-        Height = 27
-        Top = 534
+        Top = 489
       end
       inherited TreeView: TTreeView
-        Height = 513
-        Top = 21
+        Height = 470
         Images = nil
       end
     end
@@ -624,7 +619,7 @@ object SimbaForm: TSimbaForm
         SubMenuImages = Mufasa_Image_List
         OnClick = ActionNewExecute
       end
-      object MenuItemDivider: TMenuItem
+      object MenuItemDivider11: TMenuItem
         Caption = '-'
       end
       object MenuItemOpen: TMenuItem
@@ -916,6 +911,7 @@ object SimbaForm: TSimbaForm
     end
     object MenuTools: TMenuItem
       Caption = '&Tools'
+      OnClick = MenuToolsClick
       object UpdateMenuButton: TMenuItem
         Caption = '&Update'
         Bitmap.Data = {
@@ -957,6 +953,12 @@ object SimbaForm: TSimbaForm
         OnClick = UpdateMenuButtonClick
       end
       object MenuItemDivider9: TMenuItem
+        Caption = '-'
+      end
+      object MenuItemUnloadPlugin: TMenuItem
+        Caption = 'Unload Plugin'
+      end
+      object MenuItemDivider12: TMenuItem
         Caption = '-'
       end
       object MenuItemSettingsButton: TMenuItem

--- a/Units/MMLAddon/script_plugins_exports.pas
+++ b/Units/MMLAddon/script_plugins_exports.pas
@@ -1,0 +1,75 @@
+unit script_plugins_exports;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils;
+
+type
+  TSynchronizeMethod = procedure(Data: Pointer); cdecl;
+
+  TSimbaMethods = packed record
+    Synchronize: procedure(Method: TSynchronizeMethod; Data: Pointer = nil); cdecl;
+  end;
+
+  TSimbaMemoryAllocators = packed record
+    GetMem: function(Size: PtrUInt): Pointer; cdecl;
+    FreeMem: function(Ptr: Pointer): PtrUInt; cdecl;
+  end;
+
+var
+  SimbaMethods: TSimbaMethods;
+  SimbaMemoryAllocators: TSimbaMemoryAllocators;
+
+implementation
+
+function _GetMem(Size: PtrUInt): Pointer; cdecl;
+begin
+  Result := GetMem(Size);
+end;
+
+function _FreeMem(Ptr: Pointer): PtrUInt; cdecl;
+begin
+  Result := FreeMem(Ptr);
+end;
+
+type
+  TSync = class
+    Data: Pointer;
+    Method: TSynchronizeMethod;
+
+    procedure Execute;
+  end;
+
+procedure TSync.Execute;
+begin
+  Method(Data);
+end;
+
+procedure _Synchronize(Method: TSynchronizeMethod; Data: Pointer = nil); cdecl;
+var
+  Sync: TSync;
+begin
+  Sync := TSync.Create();
+  Sync.Data := Data;
+  Sync.Method := Method;
+
+  TThread.Synchronize(nil, @Sync.Execute);
+
+  Sync.Free();
+end;
+
+initialization
+  with SimbaMethods do
+    Synchronize := @_Synchronize;
+
+  with SimbaMemoryAllocators do
+  begin
+    GetMem := @_GetMem;
+    FreeMem := @_FreeMem;
+  end;
+
+end.
+


### PR DESCRIPTION
Added support for plugin unloading provided it isn't being used in a running script which is very useful for plugin dev, no longer needed to reload Simba!

![Image](https://i.imgur.com/5XTu0x4.png)

Plugins can now export a function named `SetPluginSimbaMemoryAllocators` which passes over `GetMem` and `FreeMem` methods to be used. Also a function named `SetPluginSimbaMethods` can be exported which passes over Simba's `TThread.Synchronize` method to use used.

Both these can be easily expanded on without breaking compatibility later on by just adding a new field.
