### PR TITLE
Fix IsKeyHeld on Windows | Add IsKeyHeld, better SendKeys on Linux

### DIFF
--- a/Units/MMLCore/os_windows.pas
+++ b/Units/MMLCore/os_windows.pas
@@ -434,42 +434,43 @@ begin
   SendInput(1,Input, sizeof(Input));
 end;
 
-  procedure TWindow.HoldMouse(x,y: integer; button: TClickType);
-  var
-    Input : TInput;
-    Rect : TRect;
-  begin
-    MouseApplyAreaOffset(x, y);
-    WindowRect(rect);
-    Input.Itype:= INPUT_MOUSE;
-    FillChar(Input,Sizeof(Input),0);
-    Input.mi.dx:= x + Rect.left;
-    Input.mi.dy:= y + Rect.Top;
-    case button of
-      Mouse_Left: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_LEFTDOWN;
-      Mouse_Middle: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_MIDDLEDOWN;
-      Mouse_Right: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_RIGHTDOWN;
-    end;
-    SendInput(1,Input, sizeof(Input));
+procedure TWindow.HoldMouse(x,y: integer; button: TClickType);
+var
+  Input : TInput;
+  Rect : TRect;
+begin
+  MouseApplyAreaOffset(x, y);
+  WindowRect(rect);
+  Input.Itype:= INPUT_MOUSE;
+  FillChar(Input,Sizeof(Input),0);
+  Input.mi.dx:= x + Rect.left;
+  Input.mi.dy:= y + Rect.Top;
+  case button of
+    Mouse_Left: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_LEFTDOWN;
+    Mouse_Middle: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_MIDDLEDOWN;
+    Mouse_Right: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_RIGHTDOWN;
   end;
-  procedure TWindow.ReleaseMouse(x,y: integer; button: TClickType);
-  var
-    Input : TInput;
-    Rect : TRect;
-  begin
-    MouseApplyAreaOffset(x, y);
-    WindowRect(rect);
-    Input.Itype:= INPUT_MOUSE;
-    FillChar(Input,Sizeof(Input),0);
-    Input.mi.dx:= x + Rect.left;
-    Input.mi.dy:= y + Rect.Top;
-   case button of
-      Mouse_Left: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_LEFTUP;
-      Mouse_Middle: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_MIDDLEUP;
-      Mouse_Right: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_RIGHTUP;
-    end;
-    SendInput(1,Input, sizeof(Input));
+  SendInput(1,Input, sizeof(Input));
+end;
+
+procedure TWindow.ReleaseMouse(x,y: integer; button: TClickType);
+var
+  Input : TInput;
+  Rect : TRect;
+begin
+  MouseApplyAreaOffset(x, y);
+  WindowRect(rect);
+  Input.Itype:= INPUT_MOUSE;
+  FillChar(Input,Sizeof(Input),0);
+  Input.mi.dx:= x + Rect.left;
+  Input.mi.dy:= y + Rect.Top;
+ case button of
+    Mouse_Left: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_LEFTUP;
+    Mouse_Middle: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_MIDDLEUP;
+    Mouse_Right: Input.mi.dwFlags:= MOUSEEVENTF_ABSOLUTE or MOUSEEVENTF_RIGHTUP;
   end;
+  SendInput(1,Input, sizeof(Input));
+end;
 
 function TWindow.IsMouseButtonHeld(button: TClickType): boolean;
 begin
@@ -519,20 +520,22 @@ begin
   end;
 end;
 
-procedure TWindow.HoldKey(key: integer);
+procedure TWindow.HoldKey(key: Integer);
 begin
   keyinput.Down(key);
 end;
-procedure TWindow.ReleaseKey(key: integer);
+
+procedure TWindow.ReleaseKey(key: Integer);
 begin
   keyinput.Up(key);
 end;
-function TWindow.IsKeyHeld(key: integer): boolean;
+
+function TWindow.IsKeyHeld(key: Integer): Boolean;
 begin
-  Result := (GetAsyncKeyState(key)  <> 0);
+  Result := (GetAsyncKeyState(key) and $8000 <> 0); //only check if high-order bit is set
 end;
 
-function TWindow.GetKeyCode(c: char): integer;
+function TWindow.GetKeyCode(c: Char): Integer;
 begin
   result := VkKeyScan(c) and $FF;
 end;


### PR DESCRIPTION
**Windows:**
* `IsKeyDown` checks if they key was pressed after the last call to `IsKeyDown`. This is wrong and unexpected behavior. Now it actually checks if they key is currently held.

**Linux:**
* `SendKeys`: Add a more complete version of it, where the old one only supported `[AZaz09 ]`. Now it should be notably more flexible, to some degree support none-US/EN layouts as well which is more than we get with the one on Windows. So, should at least do the job for us. 
* `IsKeyDown`: Wasn't implemented at all. now it is.