### PR TITLE
On demand font loading and IsTerminated.

### DIFF
--- a/Projects/FormDesigner/CodeGen/lpcodegen.pas
+++ b/Projects/FormDesigner/CodeGen/lpcodegen.pas
@@ -412,7 +412,7 @@ begin
          list.Add(GenSpaces(2)+ smb.compname+'.Init(Self.Form);');
          list.Add(GenSpaces(2)+'with'+GenSpaces(1)+smb.compname+GenSpaces(1)+'do');
          list.Add(GenSpaces(2)+'begin');
-         list.Add(GenSpaces(4)+'SetParent('+cmpList[0].compname+');');
+         list.Add(GenSpaces(4)+'SetParent(Self.Form);');
          list.Add(GenSpaces(4)+'SetCaption('+#39+smb.caption+#39+');');
          //list.Add(GenSpaces(4)+'Checked:=false'+';');
          list.Add(GenSpaces(4)+Format('SetBounds(%s,%s,%s,%s);',[IntToStr(smb.left),IntToStr(smb.top),IntToStr(smb.width),IntToStr(smb.height)]));
@@ -508,8 +508,12 @@ begin
       AddStrings(ComboBoxesCode);
     if RadBtnsCode.Count > 0 then
       AddStrings(RadBtnsCode);
-    Add('  Self.Form.ShowModal();');
-    Add('  Self.Form.Free();');
+    Add('  try');
+    Add('    Self.Form.ShowModal();');
+    Add('    Self.Form.Free();');
+    Add('  except');
+    Add('    WriteLn(' + #39 + 'Encountered an exception while showing the form' + #39 + ');');
+    Add('  end');
     Add('end;');
     Add('');
     Add('begin');

--- a/Projects/Simba/newsimbasettings.pas
+++ b/Projects/Simba/newsimbasettings.pas
@@ -313,7 +313,7 @@ implementation
 uses
    mufasabase,
    mufasatypes,
-   fileutil, stringutil,
+   fileutil,
    simbaunit; // mDebugLn
 
 const

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -1,7 +1,7 @@
 object SimbaForm: TSimbaForm
-  Left = 402
+  Left = 527
   Height = 773
-  Top = 115
+  Top = 112
   Width = 1200
   ActiveControl = ScriptPanel
   AllowDropFiles = True

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -47,7 +47,7 @@ uses
   SynExportHTML, SynEditKeyCmds,
   SynEditMarkupHighAll,  LMessages, Buttons, ShellCtrls, PairSplitter,
   mmisc, stringutil,mufasatypesutil,
-  about, framefunctionlist, fontloader, updateform, Simbasettingsold,
+  about, framefunctionlist, updateform, Simbasettingsold,
   Simbasettingssimple,
   v_ideCodeInsight, v_ideCodeParser, CastaliaPasLexTypes, // Code completion units
   CastaliaSimplePasPar, v_AutoCompleteForm,  // Code completion units
@@ -445,7 +445,6 @@ type
     procedure InitializeCoreBuffer;
     procedure CustomExceptionHandler(Sender: TObject; E: Exception);
     procedure RegisterSettingsOnChanges;
-    procedure LoadFonts;
     procedure FillFunctionList(Sender: TObject);
   public
     { Required to work around using freed resources on quit }
@@ -460,7 +459,6 @@ type
     ParamHint : TParamHint;
     Tabs: TList;
     Manager: TIOManager;
-    Fonts: TMFonts;
     Picker: TMColorPicker;
     Selector: TMWindowSelector;
     OnScriptStart : TScriptStartEvent;
@@ -1493,8 +1491,6 @@ begin
       Exit;
   end;
 
-  LoadFonts();
-
   try
     Thread := TMMLScriptThread.Create(Script, CurrScript.ScriptFile);
     Thread.Output := DebugMemo.Lines;
@@ -1512,8 +1508,8 @@ begin
     if Selector.HasPicked then
       Thread.Client.IOManager.SetTarget(Selector.LastPick);
 
-    Thread.SetFonts(Fonts);
     Thread.SetSettings(SimbaSettings.MMLSettings);
+    Thread.SetFonts(SimbaSettings.Fonts.Path.Value); // Create font constants
 
     CurrScript.ScriptErrorLine := -1;
   except
@@ -2464,8 +2460,6 @@ begin
     FreeAndNil(Picker);
   if (Assigned(Manager)) then
     FreeAndNil(Manager);
-  if Assigned(Fonts) then
-    FreeAndNil(Fonts);
 
   if (Assigned(RecentFiles)) then
     FreeAndNil(RecentFiles);
@@ -2938,24 +2932,6 @@ begin
 
   SimbaSettings.SourceEditor.DefScriptPath.onChange := @SetDefaultScriptPath;
   SimbaSettings.SourceEditor.Font.onChange := @SetSourceEditorFont;
-end;
-
-procedure TSimbaForm.LoadFonts;
-var
-  Directory: String;
-begin
-  if (Fonts = nil) then
-  begin
-    formWriteLn('Loading fonts...');
-
-    Fonts := TMFonts.Create(nil);
-    Fonts.Path := SimbaSettings.Fonts.Path.Value;
-
-    for Directory in GetDirectories(SimbaSettings.Fonts.Path.Value) do
-      Fonts.LoadFont(Directory, False);
-
-    formWriteLn('Loaded ' + IntToStr(Fonts.Count) + ' fonts');
-  end;
 end;
 
 procedure TSimbaForm.FileBrowserExpand(Sender: TObject; Node: TTreeNode);

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1109,6 +1109,7 @@ begin
 
     ss_Running:
       begin
+        CurrScript.ScriptThread.TerminateOptions := CurrScript.ScriptThread.TerminateOptions + [stoUserTerminated];
         CurrScript.ScriptThread.State := ssStop;
 
         ScriptState := ss_Stopping;

--- a/Units/MMLAddon/Imports/classes/MML/lptmocr.pas
+++ b/Units/MMLAddon/Imports/classes/MML/lptmocr.pas
@@ -23,13 +23,7 @@ type
 //constructor Create(Owner: TObject);
 procedure TMOCR_Init(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
-  PMOCR(Params^[0])^ := TMOCR.Create(PObject(Params^[1])^);
-end;
-
-//function InitTOCR(const path: string): boolean;
-procedure TMOCR_InitTOCR(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
-begin
-  Pboolean(Result)^ := PMOCR(Params^[0])^.InitTOCR(PlpString(Params^[1])^);
+  PMOCR(Params^[0])^ := TMOCR.Create(PObject(Params^[1])^, PBoolean(Params^[2])^);
 end;
 
 //function getTextPointsIn(sx, sy, w, h: Integer; shadow: boolean; var _chars, _shadows: T2DPointArray): Boolean;
@@ -152,20 +146,26 @@ begin
   PMOCR(Params^[0])^.Free();
 end;
 
+//  function TextToFontTPA(Text: String; Font: TFont; out W, H: Int32): TPointArray; overload;
+procedure TMOCR_TextToFontTPAEx(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PPointArray(Result)^ := PMOCR(Params^[0])^.TextToFontTPA(PlpString(Params^[1])^, PFont(Params^[2])^, Pinteger(Params^[3])^, Pinteger(Params^[4])^);
+end;
+
 procedure Register_TMOCR(Compiler: TLapeCompiler);
 begin
   with Compiler do
   begin
     addClass('TMOCR');
 
-    addGlobalFunc('procedure TMOCR.Init(Owner: TObject);', @TMOCR_Init);
-    addGlobalFunc('function TMOCR.InitTOCR(const path: string): boolean; constref;', @TMOCR_InitTOCR);
+    addGlobalFunc('procedure TMOCR.Init(Owner: TObject; UseFontBuffer: Boolean = True);', @TMOCR_Init);
     addGlobalFunc('function TMOCR.GetUpTextAtEx(atX, atY: integer; shadow: boolean; fontname: string): string; constref;', @TMOCR_GetUpTextAtEx);
     addGlobalFunc('function TMOCR.GetUpTextAt(atX, atY: integer; shadow: boolean): string; constref;', @TMOCR_GetUpTextAt);
     addGlobalFunc('function TMOCR.GetTextAt(atX, atY, minvspacing, maxvspacing, hspacing, color, tol, len: integer; font: string): string; constref;', @TMOCR_GetTextAt);
     addGlobalFunc('function TMOCR.GetTextAt(xs, ys, xe, ye, minvspacing, maxvspacing, hspacing, color, tol: integer; font: string): string; constref; overload;', @TMOCR_GetTextAtEx);
     addGlobalFunc('function TMOCR.GetTextATPA(const ATPA: T2DPointArray; const maxvspacing: integer; font: string): string; constref;', @TMOCR_GetTextATPA);
-    addGlobalFunc('function TMOCR.TextToFontTPA(Text, font: String; out w, h: integer): TPointArray; constref;', @TMOCR_TextToFontTPA);
+    addGlobalFunc('function TMOCR.TextToFontTPA(Text, Font: String; out W, H: Int32): TPointArray; overload; constref;', @TMOCR_TextToFontTPA);
+    addGlobalFunc('function TMOCR.TextToFontTPA(Text: String; Font: TFont; out W, H: Int32): TPointArray; overload; constref;', @TMOCR_TextToFontTPAEx);
     addGlobalFunc('function TMOCR.TextToFontBitmap(Text, font: String): TMufasaBitmap; constref;', @TMOCR_TextToFontBitmap);
     addGlobalFunc('function TMOCR.TextToMask(Text, font: String): TMask; constref;', @TMOCR_TextToMask);
     addClassVar('TMOCR', 'Fonts', 'TMFonts', @TMOCR_Fonts_Read, @TMOCR_Fonts_Write);

--- a/Units/MMLAddon/Imports/script_import_script.pas
+++ b/Units/MMLAddon/Imports/script_import_script.pas
@@ -45,6 +45,14 @@ begin
   TMMLScriptThread(Params^[0]).State := ssStop;
 end;
 
+procedure Lape_IsTerminated(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  if PBoolean(Params^[1])^ then
+    PBoolean(Result)^ := (stoTerminated in TMMLScriptThread(Params^[0]).TerminateOptions) and (stoUserTerminated in TMMLScriptThread(Params^[0]).TerminateOptions)
+  else
+    PBoolean(Result)^ := (stoTerminated in TMMLScriptThread(Params^[0]).TerminateOptions);
+end;
+
 procedure Lape_Import_Script(Compiler: TLapeCompiler; Data: Pointer);
 var
   Client: Pointer = nil;
@@ -70,6 +78,7 @@ begin
     addGlobalMethod('procedure WriteTimeStamp(Enable: Boolean);', @Lape_SetWriteTimeStamp, Data);
     addGlobalMethod('function GetTimeRunning: UInt64;', @Lape_GetTimeRunning, Data);
     addGlobalMethod('procedure TerminateScript;', @Lape_TerminateScript, Data);
+    addGlobalMethod('function IsTerminated(UserTerminated: Boolean = False): Boolean;', @Lape_IsTerminated, Data);
 
     addDelayedCode('var __OnTerminateStrings: array of String;'                       + LineEnding +
                    'var __OnTerminateMethods: array of procedure;'                    + LineEnding +
@@ -99,8 +108,7 @@ begin
                    'procedure AddOnTerminate(Method: procedure of object); overload;' + LineEnding +
                    'begin'                                                            + LineEnding +
                    '  __OnTerminateObjects += @Method;'                               + LineEnding +
-                   'end;',
-                   'OnTerminate');
+                   'end;', 'OnTerminate');
   end;
 end;
 

--- a/Units/MMLAddon/script_thread.pas
+++ b/Units/MMLAddon/script_thread.pas
@@ -68,7 +68,7 @@ type
     function Kill: Boolean;
 
     procedure SetSettings(From: TMMLSettings);
-    procedure SetFonts(From: TMFonts);
+    procedure SetFonts(Path: String);
 
     constructor Create(constref Script, FilePath: String);
     destructor Destroy; override;
@@ -387,16 +387,12 @@ begin
   FSettings.Prefix := 'Scripts/';
 end;
 
-procedure TMMLScriptThread.SetFonts(From: TMFonts);
+procedure TMMLScriptThread.SetFonts(Path: String);
 var
-  i: Int32;
+  Directory: String;
 begin
-  with FClient do
-  begin
-    MOCR.Fonts := From;
-    for i := 0 to MOCR.Fonts.Count - 1 do
-      FCompiler.addGlobalVar(MOCR.Fonts[i].Name, MOCR.Fonts[i].Name).isConstant := True;
-  end;
+  for Directory in GetDirectories(Path) do
+    FCompiler.addGlobalVar(Directory, Directory).isConstant := True;
 end;
 
 end.

--- a/Units/MMLAddon/script_thread.pas
+++ b/Units/MMLAddon/script_thread.pas
@@ -20,6 +20,8 @@ type
   EMMLScriptOptions = set of (soCompileOnly, soWriteTimeStamp);
   EMMLScriptState = (ssRun, ssPause, ssStop);
 
+  EMMLScriptTerminateOptions = set of (stoTerminated, stoUserTerminated);
+
   PMMLScriptThread = ^TMMLScriptThread;
   TMMLScriptThread = class(TThread)
   protected
@@ -32,6 +34,7 @@ type
     FOptions: EMMLScriptOptions;
     FSettings: TMMLSettingsSandbox;
     FUsedPlugins: TMPluginsList;
+    FTerminateOptions: EMMLScriptTerminateOptions;
 
     procedure SetState(Value: EMMLScriptState);
 
@@ -60,6 +63,7 @@ type
     property Client: TClient read FClient;
     property Settings: TMMLSettingsSandbox read FSettings;
     property StartTime: UInt64 read FStartTime;
+    property TerminateOptions: EMMLScriptTerminateOptions read FTerminateOptions write FTerminateOptions;
 
     function Kill: Boolean;
 
@@ -233,6 +237,9 @@ begin
 
       try
         RunCode(FCompiler.Emitter.Code, FRunning);
+
+        FTerminateOptions := FTerminateOptions + [stoTerminated];
+
         RunCode(FCompiler.Emitter.Code, nil, TCodePos(FCompiler.getGlobalVar('__OnTerminate').Ptr^));
       except
         on e: Exception do
@@ -267,6 +274,8 @@ begin
   FOutputBuffer := '';
 
   FUsedPlugins := TMPluginsList.Create(False);
+
+  FTerminateOptions := [];
 end;
 
 destructor TMMLScriptThread.Destroy;

--- a/Units/MMLCore/bitmaps.pas
+++ b/Units/MMLCore/bitmaps.pas
@@ -66,7 +66,7 @@ type
     procedure SetPersistentMemory(mem: PtrUInt; awidth, aheight: integer);
     procedure ResetPersistentMemory;
 
-    function PointInBitmap(x,y : integer) : boolean;
+    function PointInBitmap(x,y : integer) : boolean; inline;
     procedure ValidatePoint(x,y : integer);
     function SaveToFile(const FileName : string) :boolean;
     procedure LoadFromFile(const FileName : string);
@@ -121,8 +121,8 @@ type
     procedure LoadFromRawImage(RawImage: TRawImage);
     function CreateTMask : TMask;
     procedure ResizeBilinear(NewW, NewH: Integer);
-    procedure DrawText(const Text, FontName: string; const pnt: TPoint; const Shadow: Boolean; const Color: Integer);
-    procedure DrawSystemText(const Text, FontName: string; const FontSize: Integer; const pnt: TPoint; const Shadow: Boolean; const Color: Integer);
+    procedure DrawText(Text, Font: String; Position: TPoint; Shadow: Boolean;  Color: TColor);
+    procedure DrawSystemText(Text, Font: String; const Size: Integer; Position: TPoint; Shadow: Boolean; Color: TColor);
     procedure SetTransparentColor(Col : TColor);
     function GetTransparentColor : TColor;
     property TransparentColorSet : boolean read FTransparentSet;
@@ -787,7 +787,7 @@ begin
   end;
 end;
 
-function TMufasaBitmap.ToMatrix(): T2DIntegerArray;
+function TMufasaBitmap.ToMatrix: T2DIntegerArray;
 var
   wid, hei, x, y: integer;
 begin
@@ -1003,7 +1003,8 @@ begin
 end;
 
 //TODO - Best method would be using a mask to ignore the alpha, ie. (FDdata[c] and $FFFFFF00).
-function TMufasaBitmap.FindColors(var Points: TPointArray; const Color: integer): boolean;
+function TMufasaBitmap.FindColors(var points: TPointArray; const color: integer
+  ): boolean;
 var
   x, y, i, c,  wid, hei: integer;
   SearchColor: TRGB32;
@@ -1921,82 +1922,91 @@ begin
   end;
 end;
 
-procedure TMufasaBitmap.DrawText(const Text, FontName: string; const pnt: TPoint; const Shadow: Boolean; const Color: Integer);
+procedure TMufasaBitmap.DrawText(Text, Font: String; Position: TPoint; Shadow: Boolean; Color: TColor);
 var
   TPA: TPointArray;
-  ATPA: T2DPointArray;
-  tW, tH, i: LongInt;
+  P: TPoint;
+  RGB: TRGB32;
+  i, _: Int32;
 begin
-  if (Self.FList = nil) or (not Assigned(Self.FList)) then
-    raise Exception.Create('DrawText will not work unless the owner has been assigned');
+  if (FList = nil) then
+    raise Exception.Create('TMufasaBitmap.DrawText requires the TMBitmaps list set');
 
-  if (Text <> '') then
+  TPA := TClient(FList.Client).MOCR.TextToFontTPA(Text, Font, _, _);
+
+  if Shadow then
   begin
-    if (not TClient(Self.FList.Client).MOCR.Fonts.IsFontLoaded(FontName)) then
-      raise Exception.CreateFmt('DrawText: Font "%s" doesn''t exist', [FontName]);
+    RGB := RGBToBGR($000000);
 
-    SetLength(ATPA, 1);
-    ATPA[0] := TClient(Self.FList.Client).MOCR.TextToFontTPA(Text, FontName, tW, tH);
-
-    if (Length(ATPA[0]) > 0) then
+    for i := 0 to High(TPA) do
     begin
-      OffsetTPA(ATPA[0], Pnt);
+      P.X := TPA[i].X + Position.X + 1;
+      P.Y := TPA[i].Y + Position.Y + 1;
 
-      if (Shadow) then
-      begin
-        TPA := System.Copy(ATPA[0], 0, Length(ATPA[0]));
-        OffsetTPA(TPA, Point(1, 1));
-        SetLength(ATPA, 2); // Text & Shadow
-        ATPA[1] := ClearTPAFromTPA(TPA, ATPA[0]);
-        Inc(tW); Inc(tH); // Text will be bigger with a shadow
-      end;
-
-      for i := 0 to High(ATPA) do
-        if (ATPA[i][0].x < 0) or (ATPA[i][0].y < 0) or ((ATPA[i][0].x + tW) >= Self.Width) or ((ATPA[i][0].y + tH) >= Self.Height) then // check fits on bitmap
-          FilterPointsBox(ATPA[i], 0, 0, Self.Width - 1, Self.Height - 1);
-
-      if (not Shadow) then
-        Self.DrawTPA(ATPA[0], Color)
-      else begin
-        Self.DrawTPA(ATPA[0], Color);
-        Self.DrawTPA(ATPA[1], 0); // Shadow
-      end;
+      if PointInBitmap(P.X, P.Y) then
+        FData[P.Y * Self.W + P.X] := RGB;
     end;
   end;
+
+  RGB := RGBToBGR(Color);
+
+  for i := 0 to High(TPA) do
+  begin
+    P.X := TPA[i].X + Position.X;
+    P.Y := TPA[i].Y + Position.Y;
+
+    if PointInBitmap(P.X, P.Y) then
+      FData[P.Y * Self.W + P.X] := RGB;
+  end;
 end;
 
-// Note: The font is automaticly free'd when the client is free'd, There's a good chance the script will use it more than once so its best to keep it loaded
-procedure TMufasaBitmap.DrawSystemText(const Text, FontName: string; const FontSize: Integer; const pnt: TPoint; const Shadow: Boolean; const Color: Integer);
+procedure TMufasaBitmap.DrawSystemText(Text, Font: String; const Size: Integer; Position: TPoint; Shadow: Boolean; Color: TColor);
 var
-  f: TFont;
-  s: string;
+  TPA: TPointArray;
+  P: TPoint;
+  RGB: TRGB32;
+  i, _: Int32;
+  F: TFont;
 begin
-  if (Self.FList = nil) or (not Assigned(Self.FList)) then
-    raise Exception.Create('DrawSystemText will not work unless the owner has been assigned');
+  if (FList = nil) then
+    raise Exception.Create('TMufasaBitmap.DrawText requires the TMBitmaps list set');
 
-  s := FontName + '_' + IntToStr(FontSize);
-  if (TClient(Self.FList.Client).MOCR.Fonts.IsFontLoaded(s)) then
-  begin
-    Self.DrawText(Text, s, Pnt, Shadow, Color);
-    Exit();
-  end;
-
-  mDebugLn('Font "%s" not loaded, going to load it', [FontName]);
-  f := TFont.Create;
+  F := TFont.Create();
 
   try
-    f.Name := FontName;
-    f.Size := FontSize;
+    F.Name := Font;
+    F.Size := Size;
 
-    if (TClient(Self.FList.Client).MOCR.Fonts.LoadSystemFont(f, s)) then
-      Self.DrawText(Text, s, Pnt, Shadow, Color)
-    else
-      mDebugLn('DrawSystemText: Failed to load system font "%s"', [FontName]);
+    TPA := TClient(FList.Client).MOCR.TextToFontTPA(Text, F, _, _);
   finally
-    f.Free();
+    F.Free();
+  end;
+
+  if Shadow then
+  begin
+    RGB := RGBToBGR($000000);
+
+    for i := 0 to High(TPA) do
+    begin
+      P.X := TPA[i].X + Position.X + 1;
+      P.Y := TPA[i].Y + Position.Y + 1;
+
+      if PointInBitmap(P.X, P.Y) then
+        FData[P.Y * Self.W + P.X] := RGB;
+    end;
+  end;
+
+  RGB := RGBToBGR(Color);
+
+  for i := 0 to High(TPA) do
+  begin
+    P.X := TPA[i].X + Position.X;
+    P.Y := TPA[i].Y + Position.Y;
+
+    if PointInBitmap(P.X, P.Y) then
+      FData[P.Y * Self.W + P.X] := RGB;
   end;
 end;
-
 constructor TMBitmaps.Create(Owner: TObject);
 begin
   inherited Create;
@@ -2041,7 +2051,7 @@ end;
 
 
 { TMufasaBitmap }
-procedure TMufasaBitmap.SetSize(Awidth, Aheight: integer);
+procedure TMufasaBitmap.SetSize(AWidth, AHeight: integer);
 var
   NewData : PRGB32;
   i,minw,minh : integer;
@@ -2104,7 +2114,8 @@ begin
   end;
 end;
 
-procedure TMufasaBitmap.ResizeEx(method: TBmpResizeMethod; NewWidth, NewHeight: integer);
+procedure TMufasaBitmap.ResizeEx(Method: TBmpResizeMethod; NewWidth,
+  NewHeight: integer);
 var
   Matrix: T2DIntegerArray;
 begin

--- a/Units/MMLCore/client.pas
+++ b/Units/MMLCore/client.pas
@@ -137,9 +137,9 @@ begin
   FOwnIOManager := (UseIOManager = nil);
   MFiles := TMFiles.Create(self);
   MFinder := TMFinder.Create(Self);
-  MBitmaps := TMBitmaps.Create(self);
-  MDTMs := TMDTMS.Create(self);
-  MOCR := TMOCR.Create(self);
+  MBitmaps := TMBitmaps.Create(Self);
+  MDTMs := TMDTMS.Create(Self);
+  MOCR := TMOCR.Create(Self);
   MInternets := TMInternet.Create(Self);
   MSockets := TMSocks.Create(Self);
 end;

--- a/Units/Misc/v_ideCodeParser.pas
+++ b/Units/Misc/v_ideCodeParser.pas
@@ -620,7 +620,7 @@ begin
       else
         Insert(' ', s, a[i].StartPos - fStartPos + 1);
     end;
-    fCleanText := TrimRight(s);
+    fCleanText := s;
   end;
 
   Result := fCleanText;


### PR DESCRIPTION
### Changed font loading to only load a font set when it's required:

- Fonts are loaded to a global buffer, then copied to the scripts TMFonts instance. This means the loading of a font is only one once per Simba instance, when the font is required. 
- Correct locking is applied when accessing the global buffer for when multiple scripts are running.

This is the best option in my opinion. When loading at Simba startup issues appear when a script is instantly ran before the fonts have loaded. The other option, loading on first script compile there is a annoying few second delay. 

### function IsTerminated(UserTerminated: Boolean = False): Boolean 

Returns if the script is terminating, so this would be true while your AddOnTerminate methods are being called.
```pascal
  WriteLn(IsTerminating); // Returns true if the script is terminating
  WriteLn(IsTerminating(True)); // Returns true if the script is terminating via the user pressing the stop button.
```

Minor changes:
- Optimised and simplified TMufasaBitmap.DrawText methods
- Added `try..except..end` to Form Designer generated code to prevent crashing Simba's mainthread if something goes bad.
- Fix code completion which I broke - sorry!