### PR TITLE
Fix TTarget_Exported for x64 && Bitmap.Downsample fix.

### DIFF
--- a/Units/MMLAddon/Imports/classes/MML/lptiomanager_abstract.pas
+++ b/Units/MMLAddon/Imports/classes/MML/lptiomanager_abstract.pas
@@ -305,7 +305,7 @@ begin
   begin
     addClass('TIOManager_Abstract');
 
-    addGlobalType('record func1, func2, func3, func4, func5, func6, func7, func8, func9, func10, func11, func12, func13, func14, func15, func16: Int32; end', 'TTarget_Exported');
+    addGlobalType('record func1, func2, func3, func4, func5, func6, func7, func8, func9, func10, func11, func12, func13, func14, func15, func16: Pointer; end', 'TTarget_Exported');
     addGlobalType('record Title: String; Handle: PtrUInt; PID: UInt32; Width, Height: Int32; end', 'TSysProc');
     addGlobalType('array of TSysProc', 'TSysProcArr');
 

--- a/Units/MMLAddon/Imports/script_import_matrix.pas
+++ b/Units/MMLAddon/Imports/script_import_matrix.pas
@@ -12,6 +12,12 @@ implementation
 uses
   script_imports, lpcompiler, lptypes, mufasatypes, matrix;
 
+//procedure SetSize(a: TSingleMatrix; Width, Height: Int32);
+procedure Lape_MatrixSetSize(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  MatrixSetSize(TSingleMatrix(Params^[0]^), Int32(Params^[1]^), Int32(Params^[2]^));
+end;
+
 //procedure Size(a: TSingleMatrix; out Width, Height: Int32);
 procedure Lape_MatrixSize(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
@@ -106,6 +112,7 @@ procedure Lape_Import_Matrix(Compiler: TLapeCompiler; Data: Pointer);
 begin
   with Compiler do
   begin
+    addGlobalFunc('procedure TSingleMatrix.SetSize(Width, Height: Int32); constref;', @Lape_MatrixSetSize);
     addGlobalFunc('procedure TSingleMatrix.Size(out Width, Height: Int32); constref;', @Lape_MatrixSize);
     addGlobalFunc('function TSingleMatrix.Width(): Int32; constref;', @Lape_MatrixWidth);
     addGlobalFunc('function TSingleMatrix.Height(): Int32; constref;', @Lape_MatrixHeight);

--- a/Units/MMLAddon/Imports/script_import_matrix.pas
+++ b/Units/MMLAddon/Imports/script_import_matrix.pas
@@ -112,7 +112,7 @@ procedure Lape_Import_Matrix(Compiler: TLapeCompiler; Data: Pointer);
 begin
   with Compiler do
   begin
-    addGlobalFunc('procedure TSingleMatrix.SetSize(Width, Height: Int32); constref;', @Lape_MatrixSetSize);
+    addGlobalFunc('procedure TSingleMatrix.SetSize(Width, Height: Int32);', @Lape_MatrixSetSize);
     addGlobalFunc('procedure TSingleMatrix.Size(out Width, Height: Int32); constref;', @Lape_MatrixSize);
     addGlobalFunc('function TSingleMatrix.Width(): Int32; constref;', @Lape_MatrixWidth);
     addGlobalFunc('function TSingleMatrix.Height(): Int32; constref;', @Lape_MatrixHeight);

--- a/Units/MMLCore/bitmaps.pas
+++ b/Units/MMLCore/bitmaps.pas
@@ -1895,7 +1895,7 @@ begin
   nw := w div DownScale;
   nh := h div DownScale;
   invArea := Double(1.0) / Sqr(DownScale);
-  TargetBitmap.SetSize(nH, nW);
+  TargetBitmap.SetSize(nW, nH);
   for y:=0 to nh-1 do
     for x:=0 to nw-1 do
       TargetBitmap.FData[y*nw+x] := BlendArea(x*DownScale, y*DownScale);

--- a/Units/MMLCore/matrix.pas
+++ b/Units/MMLCore/matrix.pas
@@ -29,6 +29,7 @@ interface
 uses
   Classes, SysUtils, mufasatypes;
 
+procedure MatrixSetSize(a: TSingleMatrix; Width, Height: Int32);
 procedure MatrixSize(a: TSingleMatrix; out Width, Height: Int32);
 function MatrixWidth(a: TSingleMatrix): Int32;
 function MatrixHeight(a: TSingleMatrix): Int32;
@@ -48,6 +49,11 @@ implementation
 uses
   math;
 
+procedure MatrixSetSize(a: TSingleMatrix; Width, Height: Int32);
+begin
+  SetLength(a, Height, Width);
+end;
+
 procedure MatrixSize(a: TSingleMatrix; out Width, Height: Int32);
 begin
   Height := Length(a);
@@ -56,14 +62,14 @@ begin
   else
     Width := 0;
 end;
-  
+
 function MatrixWidth(a: TSingleMatrix): Int32;
 begin
   Result := 0;
   if Length(a) > 0 then
     Result := Length(a[0]);
 end;
-  
+
 function MatrixHeight(a: TSingleMatrix): Int32;
 begin
   Result := Length(a);

--- a/Units/MMLCore/matrix.pas
+++ b/Units/MMLCore/matrix.pas
@@ -29,7 +29,7 @@ interface
 uses
   Classes, SysUtils, mufasatypes;
 
-procedure MatrixSetSize(a: TSingleMatrix; Width, Height: Int32);
+procedure MatrixSetSize(var a: TSingleMatrix; Width, Height: Int32);
 procedure MatrixSize(a: TSingleMatrix; out Width, Height: Int32);
 function MatrixWidth(a: TSingleMatrix): Int32;
 function MatrixHeight(a: TSingleMatrix): Int32;
@@ -49,7 +49,7 @@ implementation
 uses
   math;
 
-procedure MatrixSetSize(a: TSingleMatrix; Width, Height: Int32);
+procedure MatrixSetSize(var a: TSingleMatrix; Width, Height: Int32);
 begin
   SetLength(a, Height, Width);
 end;


### PR DESCRIPTION
Fixes TTarget_Exported - The structure exported function-pointers as Int32, but that wont work on x64 targets.

TMufasaBitmap.Downsample resized the target bitmap wrongly, set width to what height should be and vice versa. I only tested with a square image, so didn't spot it.