### PR TITLE
Work around random Access Violation

### DIFF
--- a/Units/Misc/MatchTemplate/mtThreading.pas
+++ b/Units/Misc/MatchTemplate/mtThreading.pas
@@ -211,12 +211,10 @@ procedure TThreadPool.DoParallel(Method: TThreadMethod; Args: array of Pointer; 
 var
   i,step,A,B: Int32;
   Thread: array of TExecThread;
-  Params: TParamArray;
 begin
   if (fallback) or (nThreads=1) then
   begin
-    Params := Args;
-    Method(@Params, iLow, iHigh);
+    Method(@Args, iLow, iHigh);
     Exit();
   end;
 


### PR DESCRIPTION
Apparently that temporary assignment was something FPC really disliked causing random Access Violations here, could be something related to optimizations made, as I didn't get it in debug mode, none the less I didn't have to do that in the first place. And so the issue seems to have gone away as well. So I am happy.