### PR TITLE
Minor tweaks

### DIFF
--- a/Projects/Simba/framefunctionlist.lfm
+++ b/Projects/Simba/framefunctionlist.lfm
@@ -1,21 +1,21 @@
 object FunctionList_Frame: TFunctionList_Frame
   Left = 0
-  Height = 528
+  Height = 542
   Top = 0
-  Width = 225
+  Width = 322
   Align = alLeft
-  ClientHeight = 528
-  ClientWidth = 225
+  ClientHeight = 542
+  ClientWidth = 322
   OnEndDock = FrameEndDock
   ParentFont = False
   TabOrder = 0
-  DesignLeft = -314
-  DesignTop = 388
+  DesignLeft = -773
+  DesignTop = 267
   object FunctionListLabel: TLabel
     Left = 2
     Height = 15
     Top = 2
-    Width = 221
+    Width = 318
     Align = alTop
     Alignment = taCenter
     BorderSpacing.Around = 2
@@ -26,14 +26,21 @@ object FunctionList_Frame: TFunctionList_Frame
     OnMouseDown = LabelMouseDown
   end
   object Filter: TTreeFilterEdit
+    AnchorSideLeft.Control = Owner
+    AnchorSideTop.Side = asrBottom
+    AnchorSideRight.Control = btnClear
+    AnchorSideBottom.Control = Owner
+    AnchorSideBottom.Side = asrBottom
     Left = 0
     Height = 23
-    Top = 505
-    Width = 225
+    Top = 518
+    Width = 299
     OnAfterFilter = AfterFilter
     ButtonWidth = 0
     NumGlyphs = 1
-    Align = alBottom
+    Align = alCustom
+    Anchors = [akLeft, akRight, akBottom]
+    BorderSpacing.Bottom = 1
     Glyph.Data = {
       36090000424D3609000000000000360000002800000018000000180000000100
       2000000000000009000064000000640000000000000000000000000000000000
@@ -116,11 +123,15 @@ object FunctionList_Frame: TFunctionList_Frame
     FilteredTreeview = TreeView
   end
   object TreeView: TTreeView
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    AnchorSideBottom.Control = Filter
     Left = 0
-    Height = 486
+    Height = 499
     Top = 19
-    Width = 225
-    Align = alClient
+    Width = 322
+    Align = alCustom
+    Anchors = [akTop, akLeft, akRight, akBottom]
     BorderStyle = bsNone
     DragMode = dmAutomatic
     Images = SimbaForm.Mufasa_Image_List
@@ -132,5 +143,23 @@ object FunctionList_Frame: TFunctionList_Frame
     OnMouseLeave = TreeViewMouseLeave
     OnMouseMove = TreeViewMouseMove
     Options = [tvoAutoItemHeight, tvoHideSelection, tvoKeepCollapsedNodes, tvoReadOnly, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoThemedDraw]
+  end
+  object btnClear: TSpeedButton
+    AnchorSideLeft.Side = asrBottom
+    AnchorSideTop.Control = Filter
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    AnchorSideBottom.Control = Owner
+    AnchorSideBottom.Side = asrBottom
+    Left = 299
+    Height = 25
+    Top = 517
+    Width = 23
+    Align = alCustom
+    Anchors = [akTop, akRight, akBottom]
+    BorderSpacing.Around = -1
+    Caption = '✖'
+    OnClick = DoClear
+    ParentFont = False
   end
 end

--- a/Projects/Simba/framefunctionlist.lfm
+++ b/Projects/Simba/framefunctionlist.lfm
@@ -31,7 +31,7 @@ object FunctionList_Frame: TFunctionList_Frame
     Top = 505
     Width = 225
     OnAfterFilter = AfterFilter
-    ButtonWidth = 30
+    ButtonWidth = 0
     NumGlyphs = 1
     Align = alBottom
     Glyph.Data = {

--- a/Projects/Simba/framefunctionlist.pas
+++ b/Projects/Simba/framefunctionlist.pas
@@ -73,9 +73,11 @@ type
   TFunctionList_Frame = class(TFrame)
     FunctionListLabel: TLabel;
     Filter: TTreeFilterEdit;
+    btnClear: TSpeedButton;
     TreeView: TTreeView;
 
     procedure AfterFilter(Sender: TObject);
+    procedure DoClear(Sender: TObject);
 
     procedure FrameEndDock(Sender, Target: TObject; X, Y: Integer);
     procedure DockFormOnClose(Sender: TObject; var CloseAction: TCloseAction);
@@ -324,6 +326,11 @@ begin
       ScriptNode.Expand(True);
     end else
       FilteredTreeView.FullExpand();
+end;
+
+procedure TFunctionList_Frame.DoClear(Sender: TObject);
+begin
+  Filter.Clear();
 end;
 
 procedure TFunctionList_Frame.FrameEndDock(Sender, Target: TObject; X, Y: Integer);

--- a/Units/MMLAddon/Imports/script_import_script.pas
+++ b/Units/MMLAddon/Imports/script_import_script.pas
@@ -83,7 +83,7 @@ begin
 
     OnTerminate :=
       'type'                                                                                                    + LineEnding +
-      '  TTerminateMethod = record CallOnException: Boolean; end;'                                              + LineEnding +
+      '  TTerminateMethod = record Always: Boolean; end;'                                                       + LineEnding +
       '  TTerminateMethod_String = record(TTerminateMethod) Method: String; end;'                               + LineEnding +
       '  TTerminateMethod_Procedure = record(TTerminateMethod) Method: procedure; end;'                         + LineEnding +
       '  TTerminateMethod_ProcedureOfObject = record(TTerminateMethod) Method: procedure of object; end;'       + LineEnding +
@@ -104,30 +104,45 @@ begin
       '    OnTerminateProceduresOfObject[i].Method();'                                                          + LineEnding +
       'end;'                                                                                                    + LineEnding +
       ''                                                                                                        + LineEnding +
-      'procedure __OnTerminate_Exception;'                                                                      + LineEnding +
+      'procedure AddOnTerminate(Method: String); overload;'                                                     + LineEnding +
+      'begin'                                                                                                   + LineEnding +
+      '  OnTerminateStrings += TTerminateMethod_String([False, Method]);'                                       + LineEnding +
+      'end;'                                                                                                    + LineEnding +
+      ''                                                                                                        + LineEnding +
+      'procedure AddOnTerminate(Method: procedure); overload;'                                                  + LineEnding +
+      'begin'                                                                                                   + LineEnding +
+      '  OnTerminateProcedures += TTerminateMethod_Procedure([False, @Method]);'                                + LineEnding +
+      'end;'                                                                                                    + LineEnding +
+      ''                                                                                                        + LineEnding +
+      'procedure AddOnTerminate(Method: procedure of object); overload;'                                        + LineEnding +
+      'begin'                                                                                                   + LineEnding +
+      '  OnTerminateProceduresOfObject += TTerminateMethod_ProcedureOfObject([False, @Method]);'                + LineEnding +
+      'end;'                                                                                                    + LineEnding +
+      ''                                                                                                        + LineEnding +
+      'procedure __OnTerminate_Always;'                                                                         + LineEnding +
       'var i: Int32;'                                                                                           + LineEnding +
       'begin'                                                                                                   + LineEnding +
       '  for i := 0 to High(OnTerminateStrings) do'                                                             + LineEnding +
-      '    if OnTerminateStrings[i].CallOnException then VariantInvoke(OnTerminateStrings[i].Method, []);'      + LineEnding +
+      '    if OnTerminateStrings[i].Always then VariantInvoke(OnTerminateStrings[i].Method, []);'               + LineEnding +
       '  for i := 0 to High(OnTerminateProcedures) do'                                                          + LineEnding +
-      '    if OnTerminateProcedures[i].CallOnException then OnTerminateProcedures[i].Method();'                 + LineEnding +
+      '    if OnTerminateProcedures[i].Always then OnTerminateProcedures[i].Method();'                          + LineEnding +
       '  for i := 0 to High(OnTerminateProceduresOfObject) do'                                                  + LineEnding +
-      '    if OnTerminateProceduresOfObject[i].CallOnException then OnTerminateProceduresOfObject[i].Method();' + LineEnding +
+      '    if OnTerminateProceduresOfObject[i].Always then OnTerminateProceduresOfObject[i].Method();'          + LineEnding +
       'end;'                                                                                                    + LineEnding +
       ''                                                                                                        + LineEnding +
-      'procedure AddOnTerminate(Method: String; CallOnException: Boolean = False); overload;'                   + LineEnding +
+      'procedure AddOnTerminateAlways(Method: String); overload;'                                               + LineEnding +
       'begin'                                                                                                   + LineEnding +
-      '  OnTerminateStrings += TTerminateMethod_String([CallOnException, Method]);'                             + LineEnding +
+      '  OnTerminateStrings += TTerminateMethod_String([True, Method]);'                                        + LineEnding +
       'end;'                                                                                                    + LineEnding +
       ''                                                                                                        + LineEnding +
-      'procedure AddOnTerminate(Method: procedure; CallOnException: Boolean = False); overload;'                + LineEnding +
+      'procedure AddOnTerminateAlways(Method: procedure); overload;'                                            + LineEnding +
       'begin'                                                                                                   + LineEnding +
-      '  OnTerminateProcedures += TTerminateMethod_Procedure([CallOnException, @Method]);'                      + LineEnding +
+      '  OnTerminateProcedures += TTerminateMethod_Procedure([True, @Method]);'                                 + LineEnding +
       'end;'                                                                                                    + LineEnding +
       ''                                                                                                        + LineEnding +
-      'procedure AddOnTerminate(Method: procedure of object; CallOnException: Boolean = False); overload;'      + LineEnding +
+      'procedure AddOnTerminateAlways(Method: procedure of object); overload;'                                  + LineEnding +
       'begin'                                                                                                   + LineEnding +
-      '  OnTerminateProceduresOfObject += TTerminateMethod_ProcedureOfObject([CallOnException, @Method]);'      + LineEnding +
+      '  OnTerminateProceduresOfObject += TTerminateMethod_ProcedureOfObject([True, @Method]);'                 + LineEnding +
       'end;'                                                                                                    + LineEnding +
       ''                                                                                                        + LineEnding +
       'procedure DeleteOnTerminate(Method: String); overload;'                                                  + LineEnding +

--- a/Units/MMLAddon/Imports/script_import_simba.pas
+++ b/Units/MMLAddon/Imports/script_import_simba.pas
@@ -161,7 +161,7 @@ type
 
 procedure TStatus.Execute;
 begin
-  SimbaForm.StatusBar.Panels[0].Text := PString(Params^[1])^;
+  SimbaForm.StatusBar.Panels[3].Text := PString(Params^[1])^;
 end;
 
 // procedure Status(const Status: String);

--- a/Units/MMLAddon/script_plugins.pas
+++ b/Units/MMLAddon/script_plugins.pas
@@ -41,7 +41,7 @@ type
     constructor Create(Name, Str: String);
   end;
 
-  TMPluginDelayedCode = class(TMPluginDeclaration)
+  TMPluginCode = class(TMPluginDeclaration)
   protected
     FCode: String;
     FName: String;
@@ -64,8 +64,8 @@ type
     GetFunctionCount: function: Int32; cdecl;
     GetTypeInfo: function(Index: Int32; var Name: PChar; var Str: PChar): Int32; cdecl;
     GetTypeCount: function: Int32; cdecl;
-    GetDelayedCode: procedure(var Code: PChar); cdecl;
-    GetDelayedCodeLength: function: Int32; cdecl;
+    GetCode: procedure(var Code: PChar); cdecl;
+    GetCodeLength: function: Int32; cdecl;
     SetPluginMemManager: procedure(MemoryManager: TMemoryManager); cdecl;
     SetPluginSimbaMethods: procedure(Methods: TSimbaMethods); cdecl;
     SetPluginSimbaMemoryAllocators: procedure(Allocators: TSimbaMemoryAllocators); cdecl;
@@ -244,17 +244,17 @@ begin
     FStr := FStr + ';';
 end;
 
-procedure TMPluginDelayedCode.Import(Compiler: TLapeCompiler);
+procedure TMPluginCode.Import(Compiler: TLapeCompiler);
 begin
-  Compiler.addDelayedCode(FCode, FName);
+  Compiler.addDelayedCode(FCode, FName, False, True);
 end;
 
-procedure TMPluginDelayedCode.Dump(var Str: String);
+procedure TMPluginCode.Dump(var Str: String);
 begin
   Str := Str + FCode + LineEnding;
 end;
 
-constructor TMPluginDelayedCode.Create(Code, Name: String);
+constructor TMPluginCode.Create(Code, Name: String);
 begin
   FCode := Code;
   FName := Name;
@@ -317,14 +317,14 @@ begin
     end;
   end;
 
-  if (Pointer(GetDelayedCodeLength) <> nil) and (Pointer(GetDelayedCode) <> nil) then
+  if (Pointer(GetCodeLength) <> nil) and (Pointer(GetCode) <> nil) then
   begin
-    Str := StrAlloc(GetDelayedCodeLength());
+    Str := StrAlloc(GetCodeLength());
 
     try
-      GetDelayedCode(Str);
+      GetCode(Str);
 
-      FDeclarations.Add(TMPluginDelayedCode.Create(Str, ExtractFileNameOnly(FFilePath)));
+      FDeclarations.Add(TMPluginCode.Create(Str, ExtractFileNameOnly(FFilePath)));
     finally
       StrDispose(Str);
     end;
@@ -347,8 +347,8 @@ begin
     Pointer(GetFunctionCount) := GetProcedureAddress(FLib, 'GetFunctionCount');
     Pointer(GetTypeInfo) := GetProcedureAddress(FLib, 'GetTypeInfo');
     Pointer(GetTypeCount) := GetProcedureAddress(FLib, 'GetTypeCount');
-    Pointer(GetDelayedCode) := GetProcedureAddress(FLib, 'GetDelayedCode');
-    Pointer(GetDelayedCodeLength) := GetProcedureAddress(FLib, 'GetDelayedCodeLength');
+    Pointer(GetCode) := GetProcedureAddress(FLib, 'GetCode');
+    Pointer(GetCodeLength) := GetProcedureAddress(FLib, 'GetCodeLength');
     Pointer(SetPluginMemManager) := GetProcedureAddress(FLib, 'SetPluginMemManager');
     Pointer(SetPluginSimbaMethods) := GetProcAddress(FLib, 'SetPluginSimbaMethods');
     Pointer(SetPluginSimbaMemoryAllocators) := GetProcAddress(FLib, 'SetPluginSimbaMemoryAllocators');


### PR DESCRIPTION
-  Added `AddOnTerminateAlways` method which will always be called when the script is terminated in any fashion (so on unhandled exception & forceful terminate).

- `GetDelayedCode` plugin import is no longer delayed (meaning it was compiled after the script was) In this situation it gave no advantages and prevented us from being able to import `begin..end` statements to initialize things.
It's now not delayed and just inserts code normally, and has been renamed to `GetCode` to reflect the changes.
1.3 hasn't been released yet, so this change won't break anything.