### PR TITLE
Setup autobuild using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,58 @@
 # Based on .travis.yml in `travis-lazarus` (https://github.com/nielsAD/travis-lazarus)
+# Reqiures git personal access token set in Travis as a secure enviorment variable named `GITHUB_API_KEY` with `public_repo` access.
+# Travis hides secure variables AND we hide all output when the key is used so should be no issues.
 
-sudo: true
+language: generic
+sudo: required
+dist: trusty
 
 env:
   global:
     - WINEPREFIX=~/.winelaz
     - DISPLAY=:99.0
 
-matrix:
-  allow_failures:
-    - os: osx
-  include:
-    - os: osx
+jobs:
+  include: 
+    - stage: "Autobuild prepare"
+      script: python ./autobuild/travis-autobuild-prepare.py 2>&1 | tee >/dev/null
+      if: tag IS blank
+      before_install: true
+      install: true
+    - stage: "Windows 32"  
+      os: linux
+      env: LAZ_VER=1.8.2  LAZ_ENV=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
+      if: tag IS blank
+      after_failure: python ./autobuild/travis-autobuild-error.py 2>&1 | tee >/dev/null
+    - stage: "Windows 64"  
+      os: linux
+      env: LAZ_VER=1.8.2  LAZ_ENV=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
+      if: tag IS blank
+      after_failure: python ./autobuild/travis-autobuild-error.py 2>&1 | tee >/dev/null
+    - stage: "Linux 64"  
+      os: linux
       env: LAZ_VER=1.8.2
-    - os: linux
-      env: LAZ_VER=1.8.2 DOCS=test
-    - os: linux
-      env: LAZ_VER=1.8.2 LAZ_WINE=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
-    - os: linux
-      env: LAZ_VER=1.8.2 LAZ_WINE=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
+      if: tag IS blank
+      after_failure: python ./autobuild/travis-autobuild-error.py 2>&1 | tee >/dev/null
+    - stage: "Autobuild finalize"
+      script: python ./autobuild/travis-autobuild-finalize.py 2>&1 | tee >/dev/null
+      if: tag IS blank
+      before_install: true
+      install: true
 
 before_install:
-  # Install environment prerequisites
   - sudo apt-get update && sudo apt-get install xvfb python-sphinx graphviz libxtst-dev libkeybinder-dev || true
   - Xvfb $DISPLAY &
 
 install:
-  # Install testing prerequisites (wine/fpc/lazarus)
   - ./autobuild/travis-lazarus/.travis.install.py
 
 script:
-  # Generate Simba.exe in debug and release mode
-  - $LAZ_WINE lazbuild --bm=debug   $LAZ_OPT ./Projects/Simba/Simba.lpi
-  - $LAZ_WINE lazbuild --bm=release $LAZ_OPT ./Projects/Simba/Simba.lpi
-
-  # Validate references in documentation
-  - test -z "$DOCS" || make -C ./Doc $DOCS
-
-before_deploy:
-  # Generate documentation, ignore result if sphinx-build not available
-  - make -C ./Doc release tarball || ! command -v sphinx-build
-
+  - lazbuild $LAZ_OPT --bm=release "./Projects/Simba/Simba.lpi"
+  - lazbuild $LAZ_OPT --bm=debug "./Projects/Simba/Simba.lpi"
+  - python ./autobuild/travis-autobuild-upload.py 2>&1 | tee >/dev/null
+  
 notifications:
+  email: false
   irc:
     channels: "irc.rizon.net#simba"
     template:

--- a/autobuild/git.py
+++ b/autobuild/git.py
@@ -1,0 +1,44 @@
+import os
+import json
+
+def git(args):
+    os.system("curl --silent -H 'Authorization: token " + os.environ['GITHUB_API_KEY'] + "' " + args + " 2>&1 | tee >/dev/null")
+
+def git_get_releases():
+    git('-o releases https://api.github.com/repos/' + os.environ['TRAVIS_REPO_SLUG'] + '/releases')
+
+    with open('releases', 'r') as f:
+        return json.loads(f.read()) 
+
+def git_make_release_data(tag, commit, name, body, draft, prerelease):
+    arg1 = '"tag_name": "' + tag + '"'
+    arg2 = '"target_commitish": "' + commit + '"'
+    arg3 = '"name": "' + name + '"'
+    arg4 = '"body": "' + body + '"'
+    arg5 = '"draft": ' + draft
+    arg6 = '"prerelease": ' + prerelease
+
+    return '{' + arg1 + ', ' + arg2 + ', ' + arg3 + ', ' + arg4 + ', ' + arg5 + ', ' + arg6 + '}' 
+
+def git_create_release(release):
+    git("-X POST --data '" + release + "' https://api.github.com/repos/" + os.environ['TRAVIS_REPO_SLUG'] + "/releases")
+
+def git_upload_to_release(release_name, file_path):
+    for release in git_get_releases():
+        if release['name'] == release_name:
+            head, tail = os.path.split(file_path)
+            asset = 'https://uploads.github.com/repos/' + os.environ['TRAVIS_REPO_SLUG'] + '/releases/' + str(release['id']) + '/assets?name=' + tail
+            git("-X POST --data-binary @'" + file_path + "' -H 'Content-Type: application/octet-stream' " + asset)
+            break
+
+def git_edit_release(release_name, data):
+    for release in git_get_releases():
+        if release['name'] == release_name:
+            git("-X PATCH --data '" + data + "' https://api.github.com/repos/" + os.environ['TRAVIS_REPO_SLUG'] + "/releases/" + str(release['id']))
+
+def git_delete_release(release_name):
+    for release in git_get_releases():
+       if release['name'] == release_name: 
+           git("-X DELETE https://api.github.com/repos/" + os.environ['TRAVIS_REPO_SLUG'] + "/git/refs/tags/" + release['tag_name'])
+           git("-X DELETE https://api.github.com/repos/" + os.environ['TRAVIS_REPO_SLUG'] + "/releases/" + str(release['id']))  
+

--- a/autobuild/travis-autobuild-error.py
+++ b/autobuild/travis-autobuild-error.py
@@ -1,0 +1,5 @@
+import os
+from git import git_delete_release
+
+if os.environ['TRAVIS_EVENT_TYPE'] == 'push':
+   git_delete_release('autobuild-' + os.environ['TRAVIS_BUILD_NUMBER'])

--- a/autobuild/travis-autobuild-finalize.py
+++ b/autobuild/travis-autobuild-finalize.py
@@ -1,0 +1,6 @@
+import os
+from git import git_delete_release, git_edit_release, git_make_release_data
+
+if os.environ['TRAVIS_EVENT_TYPE'] == 'push':
+    git_delete_release(os.environ['TRAVIS_BRANCH'] + '-autobuild')
+    git_edit_release('autobuild-' + os.environ['TRAVIS_BUILD_NUMBER'], git_make_release_data('autobuild-' + os.environ['TRAVIS_BUILD_NUMBER'], os.environ['TRAVIS_BRANCH'], os.environ['TRAVIS_BRANCH'] + '-autobuild', 'Auto build for the ' + os.environ['TRAVIS_BRANCH'] + ' branch', 'false', 'true'))

--- a/autobuild/travis-autobuild-prepare.py
+++ b/autobuild/travis-autobuild-prepare.py
@@ -1,0 +1,5 @@
+import os
+from git import git_create_release, git_make_release_data
+
+if os.environ['TRAVIS_EVENT_TYPE'] == 'push':
+    git_create_release(git_make_release_data('autobuild-' + os.environ['TRAVIS_BUILD_NUMBER'], os.environ['TRAVIS_BRANCH'], 'autobuild-' + os.environ['TRAVIS_BUILD_NUMBER'], 'Build in progress...', 'true', 'true'))

--- a/autobuild/travis-autobuild-upload.py
+++ b/autobuild/travis-autobuild-upload.py
@@ -1,0 +1,7 @@
+import os
+from git import git_upload_to_release
+
+if os.environ['TRAVIS_EVENT_TYPE'] == 'push':
+   for file in os.listdir(os.getcwd()):
+       if file.startswith("Simba."):
+	       git_upload_to_release('autobuild-' + os.environ['TRAVIS_BUILD_NUMBER'], os.path.join(os.getcwd(), file))


### PR DESCRIPTION
Auto builds a branch when pushed to, does not store a history, only the latest version.
Example output: https://github.com/ollydev/Simba/releases/tag/autobuild-158

Steps:
1) Creates draft release (not visible to the public)
2) Builds executable and uploads to draft release, if a build fails we delete the draft and exit.
3) Delete old release and tag if exists
4) Remove the draft tag from the release, so it's visible to the public.

**Requires git personal access token set in Travis as a secure environment variable named `GITHUB_API_KEY` with `public_repo` access.**

![img](https://i.imgur.com/j2JlEgB.png)