### PR TITLE
Fix ScriptPath and default environment settings improvement

### DIFF
--- a/Projects/Simba/newsimbasettings.pas
+++ b/Projects/Simba/newsimbasettings.pas
@@ -793,22 +793,22 @@ end;
 
 procedure GetIncludePath(obj: TSetting);
 begin
-  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(GetCurrentDir()) + 'Includes' + DS;
+  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(AppPath + 'Includes');
 end;
 
 procedure GetPluginPath(obj: TSetting);
 begin
-  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(GetCurrentDir()) + 'Plugins' + DS;
+  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(AppPath + 'Plugins');
 end;
 
 procedure GetScriptPath(obj: TSetting);
 begin
-  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(GetCurrentDir()) + 'Scripts' + DS;
+  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(AppPath + 'Scripts');
 end;
 
 procedure GetFontPath(obj: TSetting);
 begin
-  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(GetCurrentDir()) + 'Fonts' + DS;
+  TPathSetting(obj).Value := IncludeTrailingPathDelimiter(AppPath + 'Fonts');
 end;
 
 procedure GetDefScriptPath(obj: TSetting);

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -17,7 +17,7 @@ object SimbaForm: TSimbaForm
   OnHide = doOnHide
   OnShortCut = FormShortCuts
   Position = poScreenCenter
-  LCLVersion = '1.8.2.0'
+  LCLVersion = '1.8.4.0'
   Visible = True
   object ToolBar: TToolBar
     Left = 0
@@ -599,6 +599,7 @@ object SimbaForm: TSimbaForm
       inherited TreeView: TTreeView
         AnchorSideRight.Control = FunctionList
         Height = 496
+        Images = nil
       end
       inherited btnClear: TSpeedButton
         AnchorSideRight.Control = FunctionList
@@ -3668,6 +3669,7 @@ object SimbaForm: TSimbaForm
     top = 48
   end
   object UpdateTimer: TTimer
+    Enabled = False
     Interval = 10000
     OnTimer = UpdateTimerCheck
     left = 336

--- a/Units/MMLAddon/Imports/script_import_script.pas
+++ b/Units/MMLAddon/Imports/script_import_script.pas
@@ -63,7 +63,7 @@ begin
   if (Data <> nil) then
   begin
     Client := @TMMLScriptThread(Data).Client;
-    ScriptPath := TMMLScriptThread(Data).ScriptFile;
+    ScriptPath := TMMLScriptThread(Data).ScriptPath;
     ScriptFile := TMMLScriptThread(Data).ScriptFile;
   end;
 


### PR DESCRIPTION
- `ScriptPath` pointed to `ScriptFile`, fixed.
- When creating default paths `AppPath` is used, not `GetCurrentDir`.
- At startup, If a path no longer exists (example: IncludePath) the default path (example: Simba/Includes) will be used.
