### PR TITLE
Windows: disable quick edit console mode.

### DIFF
--- a/Projects/Simba/Simba.lpr
+++ b/Projects/Simba/Simba.lpr
@@ -43,7 +43,7 @@ uses
   script_import_math, script_import_time_date, script_import_ocr, script_import_string,
   script_import_simba, script_import_colormath, script_import_bitmap, script_import_settings,
   script_import_dtm, script_import_file, script_import_other, script_import_script,
-  script_import_crypto;
+  script_import_crypto, script_import_deprecated;
 
 begin
   {$IF DECLARED(SetHeapTraceOutput)}

--- a/Units/MMLAddon/Imports/script_import_bitmap.pas
+++ b/Units/MMLAddon/Imports/script_import_bitmap.pas
@@ -177,7 +177,7 @@ end;
 procedure Lape_FastDrawTransparent(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
   with TMMLScriptThread(Params^[0]).Client do
-    MBitmaps[PInt32(Params^[1])^].FastDrawTransparent(PInt32(Params^[2])^, PInt32(Params^[3])^, MBitmaps[PInt32(Params^[4])^]);
+    MBitmaps[PInt32(Params^[3])^].FastDrawTransparent(PInt32(Params^[1])^, PInt32(Params^[2])^, MBitmaps[PInt32(Params^[4])^]);
 end;
 
 procedure Lape_SetTransparentColor(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}

--- a/Units/MMLAddon/Imports/script_import_deprecated.pas
+++ b/Units/MMLAddon/Imports/script_import_deprecated.pas
@@ -238,7 +238,7 @@ begin
                    '  case Prop of'                                                                                                                           + LineEnding +
                    '    SP_OnTerminate:'                                                                                                                      + LineEnding +
                    '      for i := 0 to High(OnTerminateStrings) do'                                                                                          + LineEnding +
-                   '        Value += OnTerminateStrings[i];'                                                                                                  + LineEnding +
+                   '        Value += OnTerminateStrings[i].Method;'                                                                                                  + LineEnding +
                    '  end;'                                                                                                                                   + LineEnding +
                    'end;'                                                                                                                                     + LineEnding +
                    ''                                                                                                                                         + LineEnding +


### PR DESCRIPTION
Windows has a silly feature enabled where if you click in the console, it suspends the application so you think Simba has actually frozen, when it was a silly windows feature which is auto enabled in newer versions. This PR disables it.