### PR TITLE
Tidy up handling startup parameters and add new -test option.

### DIFF
--- a/Projects/Simba/settings_const.inc
+++ b/Projects/Simba/settings_const.inc
@@ -26,18 +26,10 @@ ssCheckUpdateMinutes = ssSettings + ssUpdater + 'CheckEveryXMinutes';
 ssUpdaterLink = ssSettings + ssUpdater + 'RemoteLink';
 ssUpdaterVersionLink = ssSettings + ssUpdater + 'RemoteVersionLink';
 ssAutomaticallyUpdate = ssSettings + ssUpdater + 'AutomaticallyUpdate';
-ssUpdaterReleaseChannel = ssSettings + ssUpdater + 'ReleaseChannel';
 
-ssLoadFontsOnStart = ssSettings + ssFonts + 'LoadOnStartUp';
-ssFontsCheckForUpdates = ssSettings + ssFonts + 'CheckForUpdates';
-ssFontsVersion = ssSettings + ssFonts + 'Version';
-ssFontsLink = ssSettings + ssFonts + 'UpdateLink';
-ssFontsVersionLink = ssSettings + ssFonts + 'VersionLink';
 ssFontsPath = ssSettings + ssFonts + 'Path';
-
 ssIncludesPath = ssSettings + ssIncludes + 'Path';
-ssInterpreterType = ssSettings + ssInterpreter + 'Type';
-ssInterpreterAllowSysCalls = ssSettings + ssInterpreter + 'AllowSysCalls';
+ssPluginsPath = ssSettings + ssPlugins + 'Path';
 
 ssTabsOpenNextOnClose = ssSettings + ssTabs + 'OpenNextOnClose';
 ssTabsOpenScriptInNewTab = ssSettings + ssTabs + 'OpenScriptInNewTab';
@@ -62,12 +54,6 @@ ssSourceEditorDefScriptPath = ssSettings + ssSourceEditor + 'DefScriptPath';
 ssSourceEditorHighlighterPath = ssSettings + ssSourceEditor + 'Highlighter';
 
 ssNewsLink = ssSettings + ssNews + 'URL';
-ssPluginsPath = ssSettings + ssPlugins + 'Path';
-
-ssExtensionsExtensionN = ssExtensions + 'Extension';
-ssExtensionsPath = ssSettings + ssExtensions + 'Path';
-ssExtensionsCount = ssExtensions + 'ExtensionCount';
-ssExtensionsFileExtension = ssSettings + ssExtensions + 'FileExtension';
 
 ssTrayAlwaysVisible = ssSettings + ssTray + 'AlwaysVisible';
 

--- a/Units/MMLAddon/script_thread.pas
+++ b/Units/MMLAddon/script_thread.pas
@@ -237,10 +237,10 @@ begin
   begin
     Eval := False;
 
-    if Pos(' = ', Argument) > 0 then Op := ' = ' else
+    if Pos(' = ', Argument) > 0 then  Op := ' = ' else
     if Pos(' <> ', Argument) > 0 then Op := ' <> ' else
-    if Pos(' > ', Argument) > 0 then Op := ' > ' else
-    if Pos(' < ', Argument) > 0 then Op := ' < ' else Op := '';
+    if Pos(' > ', Argument) > 0 then  Op := ' > ' else
+    if Pos(' < ', Argument) > 0 then  Op := ' < ' else Op := '';
 
     if (Op <> '') then
     begin
@@ -313,7 +313,7 @@ begin
 
     if FCompiler.Compile() then
     begin
-      Self.Write('Compiled succesfully in ' + IntToStr(GetTickCount64() - T) + ' ms.');
+      Self.Write('Compiled successfully in ' + IntToStr(GetTickCount64() - T) + ' ms.');
       Self.WriteLn();
 
       Result := True;
@@ -354,9 +354,9 @@ begin
       end;
 
       if (GetTickCount64() - FStartTime <= 60000) then
-        WriteLn('Succesfully executed in ' + IntToStr(GetTickCount64() - FStartTime) + ' ms.')
+        WriteLn('Successfully executed in ' + IntToStr(GetTickCount64() - FStartTime) + ' ms.')
       else
-        WriteLn('Succesfully executed in ' + TimeToStr(TimeStampToDateTime(MSecsToTimeStamp(GetTickCount64() - FStartTime))) + '.');
+        WriteLn('Successfully executed in ' + TimeToStr(TimeStampToDateTime(MSecsToTimeStamp(GetTickCount64() - FStartTime))) + '.');
     end;
   finally
     Terminate();

--- a/Units/MMLAddon/settings.pas
+++ b/Units/MMLAddon/settings.pas
@@ -584,9 +584,6 @@ begin
        TSettingData(N.Data).Free;
      N.Data := TSettingData.Create;
      TSettingData(N.Data).Val := KeyValue;
-
-     mDebugLn('Setting ' + KeyName + ' to ' + KeyValue);
-
      N := N.GetNextSibling;
    end;
    result := true;


### PR DESCRIPTION
Added `-test` option, so this allows us to have SRL compiling checks on github!

It's pretty much `-run` but waits for execution to finish then writes the output and exits - error code 1 if failed and it can be done better when I attempt out of process scripts.

Here's a travis report where SRL fails to compile:
https://travis-ci.org/ollydev/SRL/jobs/463124345#L107

Does the job!
