### PR TITLE
Create Simba's own file browser component

### DIFF
--- a/Projects/Simba/Simba.lpi
+++ b/Projects/Simba/Simba.lpi
@@ -89,7 +89,7 @@
         <PackageName Value="LCL"/>
       </Item3>
     </RequiredPackages>
-    <Units Count="76">
+    <Units Count="77">
       <Unit0>
         <Filename Value="Simba.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -434,6 +434,10 @@
         <Filename Value="../../Units/MMLAddon/oswindow/oswindow_windows.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit75>
+      <Unit76>
+        <Filename Value="file_browser.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit76>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/Projects/Simba/file_browser.pas
+++ b/Projects/Simba/file_browser.pas
@@ -1,0 +1,137 @@
+unit file_browser;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  classes, sysutils, comctrls;
+
+type
+  TSimbaFileBrowser_Node = class(TTreeNode)
+  public
+    Path: String;
+    IsDirectory: Boolean;
+  end;
+
+  TSimbaFileBrowser = class(TTreeView)
+  protected
+    FRoot: String;
+
+    procedure Expand(Node: TTreeNode); override;
+    procedure SetRoot(Value: String);
+  public
+    property Root: String read FRoot write SetRoot;
+
+    procedure Refresh;
+
+    constructor Create(AOwner: TComponent); override;
+  end;
+
+implementation
+
+uses
+  fileutil,
+  simbaunit;
+
+procedure TSimbaFileBrowser.Expand(Node: TTreeNode);
+
+  procedure Populate(Parent: TTreeNode; List: TStrings; IsDirectory: Boolean; Free: Boolean);
+  var
+    Node: TSimbaFileBrowser_Node;
+    i: Int32;
+  begin
+    for i := 0 to List.Count - 1 do
+    begin
+      Node := TSimbaFileBrowser_Node.Create(Items);
+      Node.Path := List[i];
+      Node.IsDirectory := IsDirectory;
+      Node.HasChildren := IsDirectory;
+
+      if Node.IsDirectory then
+      begin
+        Node.ImageIndex := 54;
+        Node.SelectedIndex := 54;
+      end else
+      begin
+        if ExtractFileExt(Node.Path) = '.simba' then
+        begin
+          Node.ImageIndex := 8;
+          Node.SelectedIndex := 8;
+        end else
+        begin
+          Node.ImageIndex := 56;
+          Node.SelectedIndex := 56;
+        end;
+      end;
+
+      Items.AddNode(Node, Parent, ExtractFileName(Node.Path), nil, naAddChild);
+    end;
+
+    if Free then
+      List.Free();
+  end;
+
+begin
+  inherited Expand(Node);
+
+  if (Node.Count = 0) then
+  begin
+    BeginUpdate();
+
+    try
+      Populate(Node, FindAllFiles(TSimbaFileBrowser_Node(Node).Path, '', False), False, True);
+      Populate(Node, FindAllDirectories(TSimbaFileBrowser_Node(Node).Path, False), True, True);
+
+      Node.AlphaSort();
+    finally
+      EndUpdate();
+    end;
+  end;
+end;
+
+procedure TSimbaFileBrowser.SetRoot(Value: String);
+var
+  Node: TSimbaFileBrowser_Node;
+begin
+  FRoot := IncludeTrailingPathDelimiter(Value);
+  if (not DirectoryExists(FRoot)) then
+    Exit;
+
+  BeginUpdate();
+
+  try
+    Items.Clear();
+
+    Node := TSimbaFileBrowser_Node.Create(Items);
+    Node.Path := FRoot;
+    Node.IsDirectory := True;
+    Node.HasChildren := True;
+
+    with Items.AddNode(Node, nil, ExtractFileName(ExcludeTrailingPathDelimiter(FRoot)), nil, naAdd) do
+    begin
+      Expand(False);
+
+      ImageIndex := 54;
+      SelectedIndex := 54;
+    end;
+  finally
+    EndUpdate();
+  end;
+end;
+
+procedure TSimbaFileBrowser.Refresh;
+begin
+  Root := Root;
+end;
+
+constructor TSimbaFileBrowser.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+
+  Images := SimbaForm.Mufasa_Image_List;
+  Options := Options + [tvoRightClickSelect];
+end;
+
+end.
+

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -1,13 +1,13 @@
 object SimbaForm: TSimbaForm
-  Left = -1536
+  Left = -1387
   Height = 800
-  Top = 137
+  Top = 186
   Width = 1250
   ActiveControl = ScriptPanel
   AllowDropFiles = True
   Caption = 'Simba'
-  ClientHeight = 780
-  ClientWidth = 1250
+  ClientHeight = 0
+  ClientWidth = 0
   KeyPreview = True
   Menu = MainMenu
   OnClose = FormClose
@@ -481,7 +481,7 @@ object SimbaForm: TSimbaForm
       Align = alRight
       Position = 350
       SplitterType = pstVertical
-      object PanelCodeBrowser: TPairSplitterSide
+      object FileBrowserPanel: TPairSplitterSide
         Cursor = crArrow
         Left = 0
         Height = 350
@@ -489,7 +489,7 @@ object SimbaForm: TSimbaForm
         Width = 250
         ClientWidth = 250
         ClientHeight = 350
-        object lblFileBrowser: TLabel
+        object FileBrowserLabel: TLabel
           Left = 2
           Height = 15
           Top = 2
@@ -502,28 +502,10 @@ object SimbaForm: TSimbaForm
           ParentColor = False
           ParentFont = False
         end
-        object FileBrowser: TShellTreeView
-          Left = 0
-          Height = 331
-          Top = 19
-          Width = 250
-          Align = alClient
-          FileSortType = fstNone
-          Images = Mufasa_Image_List
-          ParentFont = False
-          PopupMenu = FileBrowserPopup
-          ReadOnly = True
-          RightClickSelect = True
-          TabOrder = 0
-          OnDblClick = FileBrowserDoubleClick
-          OnExpanded = FileBrowserExpand
-          Options = [tvoAutoItemHeight, tvoHideSelection, tvoKeepCollapsedNodes, tvoReadOnly, tvoRightClickSelect, tvoShowButtons, tvoShowLines, tvoShowRoot, tvoToolTips, tvoThemedDraw]
-          ObjectTypes = [otFolders, otNonFolders, otHidden]
-        end
-        object btnRefreshFileBrowser: TSpeedButton
-          AnchorSideLeft.Control = lblFileBrowser
-          AnchorSideTop.Control = lblFileBrowser
-          AnchorSideBottom.Control = lblFileBrowser
+        object FileBrowserRefreshButton: TSpeedButton
+          AnchorSideLeft.Control = FileBrowserLabel
+          AnchorSideTop.Control = FileBrowserLabel
+          AnchorSideBottom.Control = FileBrowserLabel
           AnchorSideBottom.Side = asrBottom
           Left = -2
           Height = 16
@@ -567,7 +549,7 @@ object SimbaForm: TSimbaForm
           ParentColor = False
           ParentFont = False
         end
-        object memoNotes: TMemo
+        object NotesMemo: TMemo
           Left = 0
           Height = 165
           Top = 19
@@ -3593,7 +3575,7 @@ object SimbaForm: TSimbaForm
     end
     object ActionNotes: TAction
       Caption = '&Notes'
-      OnExecute = ActionUtiltiesExecute
+      OnExecute = ActionNotesExecute
     end
     object ActionFont: TAction
       Caption = 'Font'
@@ -3605,7 +3587,7 @@ object SimbaForm: TSimbaForm
     end
     object ActionFileBrowser: TAction
       Caption = 'File Browser'
-      OnExecute = ActionUtiltiesExecute
+      OnExecute = ActionFileBrowserExecute
     end
   end
   object ScriptPopup: TPopupMenu
@@ -3684,7 +3666,7 @@ object SimbaForm: TSimbaForm
     Images = Mufasa_Image_List
     left = 592
     top = 48
-    object popupFileBrowserOpen: TMenuItem
+    object FileBrowser_PopupItem_Open: TMenuItem
       Caption = 'Open'
       Bitmap.Data = {
         36040000424D3604000000000000360000002800000010000000100000000100
@@ -3723,11 +3705,11 @@ object SimbaForm: TSimbaForm
         0000000000000000000000000000000000000000000000000000
       }
       ImageIndex = 8
-      OnClick = popupFileBrowserOpenClick
+      OnClick = FileBrowser_Popup_Open
     end
-    object popupFileBrowserOpenExternally: TMenuItem
+    object FileBrowser_PopupItem_OpenExternally: TMenuItem
       Caption = 'Open Externally'
-      OnClick = popupFileBrowserOpenExternallyClick
+      OnClick = FileBrowser_Popup_OpenExternally
     end
   end
 end

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -2187,33 +2187,22 @@ end;
 
 procedure TSimbaForm.FileBrowser_Popup_OpenExternally(Sender: TObject);
 var
-  Path: String;
+  Path, Output: String;
+  ExitStatus: Int32;
 begin
   if (FileBrowser.Selected <> nil) then
   begin
     Path := TSimbaFileBrowser_Node(FileBrowser.Selected).Path;
 
-    if DirectoryExists(Path) then
+    if TSimbaFileBrowser_Node(FileBrowser.Selected).IsDirectory then
     begin
       {$IFDEF WINDOWS}
-      ShellExecute(Handle, 'OPEN', PChar('explorer.exe'), PChar('/root, "' + Path + '"'), nil, SW_NORMAL);
+      if RunCommandInDir('', 'explorer.exe', ['/root,', '"' + Path + '"'], Output, ExitStatus) <> 0 then
+        ShowMessage('Unable to open explorer.exe: ' + Output);
       {$ENDIF}
-
       {$IFDEF LINUX}
-      with TProcess.Create(nil) do
-      try
-        Executable := 'xdg-open';
-        Parameters.Add(Path);
-
-        try
-          Execute();
-        except
-          on e: Exception do
-            ShowMessage('Unable to open file explorer: ' + e.Message);
-        end;
-      finally
-        Free();
-      end;
+      if RunCommandInDir('', 'xdg-open', [Path], Output, ExitStatus) <> 0 then
+        ShowMessage('Unable to open xdg-open: ' + Output);
       {$ENDIF}
     end else
     if FileExists(Path) then


### PR DESCRIPTION
Continuing from #466. (git closed it automatically while fixing conflicts)

And:
+ Disable/Enable popup items depending on what node is selected.
+ Linux: Handle exception if `xdg-open` isn't available.
+ Remove two deprecated LCL methods which are now removed in Lazarus 2.0. (Lazarus 2.0 still uses FPC 3.0.4 so there are no other updating needed)