### PR TITLE
Fix function list hint showing when simba isn't focused.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "PascalScript"]
-	path = Units/PascalScript
-	url = git://github.com/SRL/PascalScript.git
 [submodule "autobuild/travis-lazarus"]
 	path = autobuild/travis-lazarus
 	url = https://github.com/nielsAD/travis-lazarus.git

--- a/Projects/Simba/framefunctionlist.pas
+++ b/Projects/Simba/framefunctionlist.pas
@@ -29,7 +29,8 @@ interface
 uses
   Classes, SysUtils, FileUtil, TreeFilterEdit, LResources, Forms,
   ComCtrls, StdCtrls, Controls, ExtCtrls, Buttons,
-  v_ideCodeParser, v_ideCodeInsight;
+  v_ideCodeParser, v_ideCodeInsight,
+  simbahintwindow;
 
 type
   TFunctionList_Frame = class;
@@ -64,7 +65,7 @@ type
     destructor Destroy; override;
   end;
 
-  TFunctionList_Hint = class(THintWindow)
+  TFunctionList_Hint = class(TSimbaHintWindow)
     procedure Paint; override; // Default drawing will clip the text
   end;
 
@@ -89,7 +90,7 @@ type
     procedure HintMouseLeave(Sender: TObject);
   protected
     FUpdater: TFunctionList_Updater;
-    FHint: THintWindow;
+    FHint: TFunctionList_Hint;
   public
     ScriptNode: TTreeNode;
     PluginsNode: TTreeNode;
@@ -637,7 +638,7 @@ end;
 
 procedure TFunctionList_Frame.TreeViewMouseLeave(Sender: TObject);
 begin
-  if (not PtInRect(TreeView.ClientRect, ScreenToClient(Mouse.CursorPos))) then
+  if (not PtInRect(TreeView.ClientRect, TreeView.ScreenToClient(Mouse.CursorPos))) then
     FHint.Hide();
 end;
 

--- a/Projects/Simba/simbahintwindow.pas
+++ b/Projects/Simba/simbahintwindow.pas
@@ -1,0 +1,61 @@
+unit simbahintwindow;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, Forms;
+
+type
+  TSimbaHintWindow = class(THintWindow)
+  protected
+    FApplicationActivated: Boolean;
+
+    procedure SetVisible(Value: Boolean); override;
+
+    procedure ApplicationActivate(Sender: TObject);
+    procedure ApplicationDeactivate(Sender: TObject);
+  public
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+  end;
+
+implementation
+
+procedure TSimbaHintWindow.ApplicationActivate(Sender: TObject);
+begin
+  FApplicationActivated := True;
+end;
+
+procedure TSimbaHintWindow.ApplicationDeactivate(Sender: TObject);
+begin
+  Visible := False;
+
+  FApplicationActivated := False;
+end;
+
+procedure TSimbaHintWindow.SetVisible(Value: Boolean);
+begin
+  if FApplicationActivated then
+    inherited SetVisible(Value);
+end;
+
+constructor TSimbaHintWindow.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+
+  Application.AddOnActivateHandler(@ApplicationActivate);
+  Application.AddOnDeactivateHandler(@ApplicationDeactivate);
+end;
+
+destructor TSimbaHintWindow.Destroy;
+begin
+  Application.RemoveOnActivateHandler(@ApplicationActivate);
+  Application.RemoveOnDeactivateHandler(@ApplicationDeactivate);
+
+  inherited Destroy();
+end;
+
+end.
+

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1360,10 +1360,9 @@ begin
   Self.CurrScript := Script;
   Self.CurrTab := Tab;
   SetScriptState(Tab.ScriptFrame.FScriptState);//To set the buttons right
-  if Self.Showing then
-    if Tab.TabSheet.TabIndex = Self.PageControl1.TabIndex then
-      if CurrScript.SynEdit.CanFocus then
-        CurrScript.SynEdit.SetFocus;      // XXX: This is never called
+  // Only focus editor if Simba is focused and tab is currently showing.
+  if Self.Focused and (Tab.TabSheet.TabIndex = Self.PageControl1.TabIndex) and CurrScript.SynEdit.CanFocus() then
+    CurrScript.SynEdit.SetFocus();
 
   StopCodeCompletion;//To set the highlighting back to normal;
 


### PR DESCRIPTION
Previously, if Simba wasn't the active window and you moused over the function list the hint would still appear and even be on top of the currently active window on your system. 

This fixes that.