### PR TITLE
Fixes Ok/Cancel button from being covered up in simple settings form

### DIFF
--- a/Projects/Simba/simbasettingssimple.lfm
+++ b/Projects/Simba/simbasettingssimple.lfm
@@ -14,7 +14,7 @@ object SettingsSimpleForm: TSettingsSimpleForm
   OnCreate = FormCreate
   OnShow = FormShow
   Position = poMainFormCenter
-  LCLVersion = '1.8.2.0'
+  LCLVersion = '1.8.4.0'
   object ButtonOK: TButton
     Left = 280
     Height = 25
@@ -92,16 +92,16 @@ object SettingsSimpleForm: TSettingsSimpleForm
   end
   object Tabs: TNotebook
     Left = 0
-    Height = 428
+    Height = 380
     Top = 72
     Width = 457
-    PageIndex = 1
-    Align = alBottom
+    PageIndex = 0
+    Align = alTop
     TabOrder = 3
     object TabGeneral: TPage
       object PgControlGeneral: TPageControl
         Left = 0
-        Height = 428
+        Height = 380
         Top = 0
         Width = 457
         ActivePage = tsUpdater
@@ -112,7 +112,7 @@ object SettingsSimpleForm: TSettingsSimpleForm
           Caption = 'Updater'
           ChildSizing.TopBottomSpacing = 10
           ChildSizing.VerticalSpacing = 10
-          ClientHeight = 400
+          ClientHeight = 352
           ClientWidth = 449
           object UpdaterGroup: TGroupBox
             AnchorSideLeft.Control = tsUpdater


### PR DESCRIPTION
The tabs on simple settings form were covering up the Ok and Cancel buttons so I changed the height of the tabs from 426 to 380 and changed the align from bottom to top so the buttons are uncovered. I just started with Simba and fpc so let me know if there is a better way to handle this fix..