### PR TITLE
Set correct directory separators when searching and loading plugin

### DIFF
--- a/Units/MMLAddon/script_plugins.pas
+++ b/Units/MMLAddon/script_plugins.pas
@@ -382,7 +382,7 @@ function TMPlugins.FindFile(Sender, Argument: String): String;
 
   function Find(Path: String; var Plugin: String): Boolean;
   begin
-    Path := IncludeTrailingPathDelimiter(Path) + Argument;
+    Path := SetDirSeparators(IncludeTrailingPathDelimiter(Path) + Argument);
 
     if FileExists(Path) then
       Plugin := Path


### PR DESCRIPTION
Issue was it could load the same plugin twice.