### PR TITLE
Add TTarget.CopyData

### DIFF
--- a/Units/MMLAddon/imports/classes/MML/lptiomanager_abstract.pas
+++ b/Units/MMLAddon/imports/classes/MML/lptiomanager_abstract.pas
@@ -77,6 +77,12 @@ begin
   PRetData(Result)^ := PIOManager_Abstract(Params^[0])^.ReturnData(PInteger(Params^[1])^, PInteger(Params^[2])^, PInteger(Params^[3])^, PInteger(Params^[4])^);
 end;
 
+//function CopyData(X, Y, Width, Height: Integer): PRGB32;
+procedure TIOManager_Abstract_CopyData(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PPRGB32(Result)^ := PIOManager_Abstract(Params^[0])^.CopyData(PInteger(Params^[1])^, PInteger(Params^[2])^, PInteger(Params^[3])^, PInteger(Params^[4])^);
+end;
+
 //procedure FreeReturnData;
 procedure TIOManager_Abstract_FreeReturnData(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
@@ -297,6 +303,7 @@ begin
     addGlobalFunc('function TIOManager_Abstract.TargetValid(): Boolean; constref;', @TIOManager_Abstract_TargetValid);
     addGlobalFunc('procedure TIOManager_Abstract.BitmapDestroyed(Bitmap : TMufasaBitmap); constref;', @TIOManager_Abstract_BitmapDestroyed);
     addGlobalFunc('function TIOManager_Abstract.GetColor(x,y : integer): TColor; constref;', @TIOManager_Abstract_GetColor);
+    addGlobalFunc('function TIOManager_Abstract.CopyData(X, Y, Width, Height: Integer): PRGB32; constref;', @TIOManager_Abstract_CopyData);
     addGlobalFunc('function TIOManager_Abstract.ReturnData(xs, ys, width, height: Integer): TRetData; constref;', @TIOManager_Abstract_ReturnData);
     addGlobalFunc('procedure TIOManager_Abstract.FreeReturnData(); constref;', @TIOManager_Abstract_FreeReturnData);
     addGlobalFunc('procedure TIOManager_Abstract.GetDimensions(out W, H: Integer); constref;', @TIOManager_Abstract_GetDimensions);

--- a/Units/MMLAddon/imports/classes/MML/lpttarget.pas
+++ b/Units/MMLAddon/imports/classes/MML/lpttarget.pas
@@ -39,6 +39,12 @@ begin
   PColor(Result)^ := PTarget(Params^[0])^.GetColor(Pinteger(Params^[1])^, Pinteger(Params^[2])^);
 end;
 
+//function CopyData(X, Y, Width, Height: Integer): PRGB32; virtual;
+procedure TTarget_CopyData(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PPRGB32(Result)^ := PTarget(Params^[0])^.CopyData(PInteger(Params^[1])^, PInteger(Params^[2])^, PInteger(Params^[3])^, PInteger(Params^[4])^);
+end;
+
 //function ReturnData(xs, ys, width, height: Integer): TRetData; virtual;
 procedure TTarget_ReturnData(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
@@ -182,6 +188,7 @@ begin
     addGlobalFunc('procedure TTarget.GetTargetDimensions(out w, h: integer); constref;', @TTarget_GetTargetDimensions);
     addGlobalFunc('procedure TTarget.GetTargetPosition(out left, top: integer); constref;', @TTarget_GetTargetPosition);
     addGlobalFunc('function TTarget.GetColor(x,y : integer): TColor; constref;', @TTarget_GetColor);
+    addGlobalFunc('function TTarget.CopyData(X, Y, Width, Height: Integer): PRGB32; constref;', @TTarget_CopyData);
     addGlobalFunc('function TTarget.ReturnData(xs, ys, width, height: Integer): TRetData; constref;', @TTarget_ReturnData);
     addGlobalFunc('procedure TTarget.FreeReturnData(); constref;', @TTarget_FreeReturnData);
     addGlobalFunc('procedure TTarget.ActivateClient(); constref;', @TTarget_ActivateClient);

--- a/Units/MMLCore/os_linux.pas
+++ b/Units/MMLCore/os_linux.pas
@@ -36,6 +36,7 @@ type
   public
     procedure GetTargetDimensions(out w, h: integer); override;
     procedure GetTargetPosition(out left, top: integer); override;
+    function CopyData(X, Y, Width, Height: Integer): PRGB32; override;
     function ReturnData(xs, ys, width, height: Integer): TRetData; override;
     procedure FreeReturnData; override;
 
@@ -209,6 +210,20 @@ end;
 procedure TWindow.ActivateClient;
 begin
   _XSetActiveWindow(Self.Window);
+end;
+
+function TWindow.CopyData(X, Y, Width, Height: Integer): PRGB32;
+begin
+  Result := GetMem(Width * Height * SizeOf(TRGB32));
+
+  Self.Buffer := _XGetWindowImage(Self.Window, X, Y, Width, Height);
+
+  if (Self.Buffer <> nil) then
+  try
+    Move(Self.Buffer^.Data^, Result^, Width * Height * SizeOf(TRGB32));
+  finally
+    XDestroyImage(Self.Buffer);
+  end;
 end;
 
 function TWindow.ReturnData(xs, ys, width, height: Integer): TRetData;


### PR DESCRIPTION
`TTarget.ReturnData` uses a internal buffer for a optimisation which isn't thread safe so, I've added `TTarget.CopyData` to all the targets. It's marginally slower but is thread safe.

The user manages the returned data which can be freed with `FreeMem`.