### PR TITLE
Script commenter

### DIFF
--- a/Projects/Simba/Simba.lpi
+++ b/Projects/Simba/Simba.lpi
@@ -290,6 +290,7 @@
         <Filename Value="simbasettingssimple.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="SettingsSimpleForm"/>
+        <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
       </Unit40>
       <Unit41>

--- a/Projects/Simba/Simba.lpi
+++ b/Projects/Simba/Simba.lpi
@@ -290,7 +290,6 @@
         <Filename Value="simbasettingssimple.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="SettingsSimpleForm"/>
-        <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
       </Unit40>
       <Unit41>

--- a/Projects/Simba/framescript.pas
+++ b/Projects/Simba/framescript.pas
@@ -316,7 +316,7 @@ begin
   if ((ssCtrl in Shift) and (not ((ssShift in Shift) and not (ssAlt in Shift)))) then
    begin
     if (Key = VK_LCL_SLASH) then
-    SimbaForm.ActCodeCommentExecute(Sender);
+    SimbaForm.ActionCodeCommentExecute(Sender);
    end;
 
   SimbaForm.CodeCompletionForm.HandleKeyDown(Sender, Key, Shift);

--- a/Projects/Simba/framescript.pas
+++ b/Projects/Simba/framescript.pas
@@ -314,10 +314,10 @@ begin
     SimbaForm.ParamHint.Hide;
 
   if ((ssCtrl in Shift) and (not ((ssShift in Shift) and not (ssAlt in Shift)))) then
-   begin
-    if (Key = VK_LCL_SLASH) then
-    SimbaForm.ActionCodeCommentExecute(Sender);
-   end;
+    begin
+      if (Key = VK_LCL_SLASH) then
+        SimbaForm.ActionCodeCommentExecute(Sender);
+    end;
 
   SimbaForm.CodeCompletionForm.HandleKeyDown(Sender, Key, Shift);
 end;

--- a/Projects/Simba/framescript.pas
+++ b/Projects/Simba/framescript.pas
@@ -313,6 +313,12 @@ begin
   else if (Key = VK_ESCAPE) then
     SimbaForm.ParamHint.Hide;
 
+  if ((ssCtrl in Shift) and (not ((ssShift in Shift) and not (ssAlt in Shift)))) then
+   begin
+    if (Key = VK_LCL_SLASH) then
+    SimbaForm.ActCodeCommentExecute(Sender);
+   end;
+
   SimbaForm.CodeCompletionForm.HandleKeyDown(Sender, Key, Shift);
 end;
 

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -1,13 +1,13 @@
 object SimbaForm: TSimbaForm
-  Left = 226
+  Left = 761
   Height = 773
-  Top = 34
+  Top = 128
   Width = 1250
   ActiveControl = ScriptPanel
   AllowDropFiles = True
   Caption = 'Simba'
-  ClientHeight = 0
-  ClientWidth = 0
+  ClientHeight = 773
+  ClientWidth = 1250
   KeyPreview = True
   Menu = MainMenu
   OnClose = FormClose

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -3589,9 +3589,9 @@ object SimbaForm: TSimbaForm
       Caption = 'File Browser'
       OnExecute = ActionFileBrowserExecute
     end
-    object ActCodeComment: TAction
-      Caption = 'ActCodeComment'
-      OnExecute = ActCodeCommentExecute
+    object ActionCodeComment: TAction
+      Caption = 'Code Comment'
+      OnExecute = ActionCodeCommentExecute
     end
   end
   object ScriptPopup: TPopupMenu

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -1,13 +1,13 @@
 object SimbaForm: TSimbaForm
-  Left = 761
+  Left = 226
   Height = 773
-  Top = 128
+  Top = 34
   Width = 1250
   ActiveControl = ScriptPanel
   AllowDropFiles = True
   Caption = 'Simba'
-  ClientHeight = 773
-  ClientWidth = 1250
+  ClientHeight = 0
+  ClientWidth = 0
   KeyPreview = True
   Menu = MainMenu
   OnClose = FormClose
@@ -17,7 +17,7 @@ object SimbaForm: TSimbaForm
   OnHide = doOnHide
   OnShortCut = FormShortCuts
   Position = poScreenCenter
-  LCLVersion = '1.8.2.0'
+  LCLVersion = '1.8.4.0'
   Visible = True
   object ToolBar: TToolBar
     Left = 0

--- a/Projects/Simba/simbaunit.lfm
+++ b/Projects/Simba/simbaunit.lfm
@@ -17,7 +17,7 @@ object SimbaForm: TSimbaForm
   OnHide = doOnHide
   OnShortCut = FormShortCuts
   Position = poScreenCenter
-  LCLVersion = '1.8.1.0'
+  LCLVersion = '1.8.2.0'
   Visible = True
   object ToolBar: TToolBar
     Left = 0
@@ -3588,6 +3588,10 @@ object SimbaForm: TSimbaForm
     object ActionFileBrowser: TAction
       Caption = 'File Browser'
       OnExecute = ActionFileBrowserExecute
+    end
+    object ActCodeComment: TAction
+      Caption = 'ActCodeComment'
+      OnExecute = ActCodeCommentExecute
     end
   end
   object ScriptPopup: TPopupMenu

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1775,23 +1775,15 @@ end;
 
 procedure TSimbaForm.ActCodeCommentExecute(Sender: TObject);
 var
-  ScriptCommenter: TScriptCommenter;
   CurPos: TPoint;
 begin
-  with CurrScript.SynEdit do
   begin
-    ScriptCommenter := TScriptCommenter.Create(BlockBegin.y-1, BlockEnd.y-1);
     try
-      try
-        CurPos := CaretXY;
-        ScriptCommenter.Lines := Lines;
-        ScriptCommenter.Process;
-        CaretXY := CurPos;
-      except
-        mDebugLn('Cannot comment the selected code!');
-      end;
-    finally
-      ScriptCommenter.Free;
+      CurPos := CurrScript.SynEdit.CaretXY;
+      TScriptCommenter.Process(CurrScript.SynEdit);
+      CurrScript.SynEdit.CaretXY := CurPos;
+    except
+      mDebugLn('Cannot comment the selected code!');
     end;
   end;
 end;

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -1777,14 +1777,12 @@ procedure TSimbaForm.ActionCodeCommentExecute(Sender: TObject);
 var
   CurPos: TPoint;
 begin
-  begin
-    try
-      CurPos := CurrScript.SynEdit.CaretXY;
-      TScriptCommenter.Process(CurrScript.SynEdit);
-      CurrScript.SynEdit.CaretXY := CurPos;
-    except
-      mDebugLn('Cannot comment the selected code!');
-    end;
+  try
+    CurPos := CurrScript.SynEdit.CaretXY;
+    TScriptCommenter.Process(CurrScript.SynEdit);
+    CurrScript.SynEdit.CaretXY := CurPos;
+  except
+    mDebugLn('Cannot comment the selected code!');
   end;
 end;
 

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -91,6 +91,7 @@ type
   { TSimbaForm }
 
   TSimbaForm = class(TForm)
+    ActCodeComment: TAction;
     ActionColors: TAction;                     
     ActionFileBrowser: TAction;
     ActionFindPrev: TAction;
@@ -284,7 +285,8 @@ type
     ToolButton8: TToolButton;
     MTrayIcon: TTrayIcon;
     FunctionListHint: THintWindow;
-    procedure ActionColorsExecute(Sender: TObject);                                            
+    procedure ActCodeCommentExecute(Sender: TObject);
+    procedure ActionColorsExecute(Sender: TObject);
     procedure ActionClearDebugExecute(Sender: TObject);
     procedure ActionCloseTabExecute(Sender: TObject);
     procedure ActionCompileScriptExecute(Sender: TObject);
@@ -540,7 +542,7 @@ uses
    math,
    script_imports, script_plugins,
    simba.environment, simba.httpclient,
-   aca, dtm_editor, colorscheme
+   aca, dtm_editor, scriptcommenter, colorscheme
    {$IFDEF USE_FORMDESIGNER}, frmdesigner{$ENDIF}
 
    {$IFDEF LINUX_HOTKEYS}, keybinder{$ENDIF};
@@ -1769,6 +1771,29 @@ end;
 procedure TSimbaForm.ActionColorsExecute(Sender: TObject);
 begin
   SimbaColors.Show();
+end;
+
+procedure TSimbaForm.ActCodeCommentExecute(Sender: TObject);
+var
+  ScriptCommenter: TScriptCommenter;
+  CurPos: TPoint;
+begin
+  with CurrScript.SynEdit do
+  begin
+    ScriptCommenter := TScriptCommenter.Create(BlockBegin.y-1, BlockEnd.y-1);
+    try
+      try
+        CurPos := CaretXY;
+        ScriptCommenter.Lines := Lines;
+        ScriptCommenter.Process;
+        CaretXY := CurPos;
+      except
+        mDebugLn('Cannot comment the selected code!');
+      end;
+    finally
+      ScriptCommenter.Free;
+    end;
+  end;
 end;
 
 procedure TSimbaForm.ActionGotoExecute(Sender: TObject);

--- a/Projects/Simba/simbaunit.pas
+++ b/Projects/Simba/simbaunit.pas
@@ -91,7 +91,7 @@ type
   { TSimbaForm }
 
   TSimbaForm = class(TForm)
-    ActCodeComment: TAction;
+    ActionCodeComment: TAction;
     ActionColors: TAction;                     
     ActionFileBrowser: TAction;
     ActionFindPrev: TAction;
@@ -285,7 +285,7 @@ type
     ToolButton8: TToolButton;
     MTrayIcon: TTrayIcon;
     FunctionListHint: THintWindow;
-    procedure ActCodeCommentExecute(Sender: TObject);
+    procedure ActionCodeCommentExecute(Sender: TObject);
     procedure ActionColorsExecute(Sender: TObject);
     procedure ActionClearDebugExecute(Sender: TObject);
     procedure ActionCloseTabExecute(Sender: TObject);
@@ -1773,7 +1773,7 @@ begin
   SimbaColors.Show();
 end;
 
-procedure TSimbaForm.ActCodeCommentExecute(Sender: TObject);
+procedure TSimbaForm.ActionCodeCommentExecute(Sender: TObject);
 var
   CurPos: TPoint;
 begin

--- a/Projects/Tools/scriptcommenter.pas
+++ b/Projects/Tools/scriptcommenter.pas
@@ -23,7 +23,9 @@ implementation
 
 class procedure TScriptCommenter.Process(Syn: TSynEdit);
 var
-  i, SelStart, SelEnd, temp: integer;
+  i, SelStart, SelEnd, ColStart, temp: integer;
+  StartStr: String;
+
 begin
   SelStart := Syn.BlockBegin.y;
   SelEnd := Syn.BlockEnd.y;
@@ -38,15 +40,18 @@ begin
   try
     Syn.BeginUndoBlock;
     try
-      if Syn.Lines[SelStart - 1].StartsWith('//') then
+      StartStr := Syn.Lines[SelStart - 1].TrimLeft();
+      ColStart := Syn.Lines[SelStart - 1].IndexOf(StartStr) + 1;
+
+      if StartStr.StartsWith('//') then
       begin
         for i := SelStart to SelEnd do
-            if Syn.Lines[i - 1].StartsWith('//') then
-              Syn.TextBetweenPoints[Point(0, i), Point(3, i)] := '';
+          if Syn.Lines[i - 1].TrimLeft().StartsWith('//') then
+            Syn.TextBetweenPoints[Point(ColStart, i), Point(ColStart + 2, i)] := '';
       end
       else
-          for i := SelStart to SelEnd do
-              Syn.TextBetweenPoints[Point(0, i), Point(0, i)] := '//';
+        for i := SelStart to SelEnd do
+          Syn.TextBetweenPoints[Point(ColStart, i), Point(ColStart, i)] := '//';
     finally
       Syn.EndUndoBlock;
     end;

--- a/Projects/Tools/scriptcommenter.pas
+++ b/Projects/Tools/scriptcommenter.pas
@@ -1,0 +1,65 @@
+unit scriptcommenter;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils;
+
+type
+
+  { TScriptCommenter }
+
+  TScriptCommenter = class
+  private
+    FSelStart: integer;
+    FSelEnd: integer;
+    FLines: TStrings;
+    procedure Clear;
+  public
+    constructor Create(const SStart, SSEnd: integer);
+    property SelStart: integer read FSelStart write FSelStart;
+    property SelEnd: integer read FSelEnd write FSelEnd;
+    property Lines: TStrings read FLines write FLines;
+
+    procedure Process;
+
+  end;
+
+implementation
+
+{ TScriptCommenter }
+
+procedure TScriptCommenter.Clear;
+begin
+  FSelStart := -1;
+  FSelEnd := -1;
+end;
+
+constructor TScriptCommenter.Create(const SStart, SSEnd: integer);
+begin
+  Clear;
+  SelStart := SStart;
+  SelEnd := SSEnd;
+end;
+
+procedure TScriptCommenter.Process;
+var
+  i: integer;
+  Str: string;
+begin
+  for i := SelStart to SelEnd do
+  begin
+    Str := Lines.Strings[i];
+    if ((Length(Str) > 3) and (Str[1] = '/') and (Str[2] = '/')) then
+    begin
+      Str := copy(Str, 3, length(Str) - 2);
+    end
+    else if (Length(Str) > 1) then
+      Str := '//' + Str;
+    Lines.Strings[i] := str;
+  end;
+end;
+
+end.


### PR DESCRIPTION
This is the same script-commenter from PR#479.
Comments start at first non-whitspace character of first line of selection, and form a straight column down.
Changed 'ActCodeComment' to 'ActionCodeComment' to remain consistent with naming convention for project.
Compatible with undo command.

I accidentally butchered the last PR because I'm not very experienced with git yet, so I apologize for the duplicate PR :/