### PR TITLE
Add FindText (not OCR)

### DIFF
--- a/Units/MMLAddon/imports/classes/MML/lptiomanager.pas
+++ b/Units/MMLAddon/imports/classes/MML/lptiomanager.pas
@@ -66,6 +66,11 @@ begin
   PColor(Result)^ := PIOManager(Params^[0])^.GetColor(Pinteger(Params^[1])^, Pinteger(Params^[2])^);
 end;
 
+procedure TIOManager_ReturnMatrix(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PIntegerMatrix(Result)^ := PIOManager(Params^[0])^.ReturnMatrix(PInteger(Params^[1])^, PInteger(Params^[2])^, PInteger(Params^[3])^, PInteger(Params^[4])^);
+end;
+
 //function ReturnData(xs, ys, width, height: Integer): TRetData;
 procedure TIOManager_ReturnData(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
@@ -310,7 +315,8 @@ begin
     addGlobalFunc('function TIOManager.TargetValid(): Boolean; constref;', @TIOManager_TargetValid);
     addGlobalFunc('function TIOManager.GetColor(x,y : integer): TColor; constref;', @TIOManager_GetColor);
     addGlobalFunc('function TIOManager.CopyData(X, Y, Width, Height: Integer): PRGB32; constref;', @TIOManager_CopyData);
-    addGlobalFunc('function TIOManager.ReturnData(xs, ys, width, height: Integer): TRetData; constref;', @TIOManager_ReturnData);
+    addGlobalFunc('function TIOManager.ReturnMatrix(X, Y, Width, Height: Integer): TIntegerMatrix; constref;', @TIOManager_ReturnMatrix);
+    addGlobalFunc('function TIOManager.ReturnData(X, Y, Width, Height: Integer): TRetData; constref;', @TIOManager_ReturnData);
     addGlobalFunc('procedure TIOManager.FreeReturnData(); constref;', @TIOManager_FreeReturnData);
     addGlobalFunc('procedure TIOManager.GetDimensions(out W, H: Integer); constref;', @TIOManager_GetDimensions);
     addGlobalFunc('procedure TIOManager.GetPosition(var Left, Top: Integer); constref;', @TIOManager_GetPosition);

--- a/Units/MMLAddon/imports/script_import_finder.pas
+++ b/Units/MMLAddon/imports/script_import_finder.pas
@@ -236,6 +236,36 @@ begin
     PBoolean(Result)^ := MFinder.FindTemplate(TMufasaBitmap(Params^[1]^), Int32(Params^[2]^), Int32(Params^[3]^), ETMFormula(Params^[4]^), Int32(Params^[5]^), Int32(Params^[6]^), Int32(Params^[7]^), Int32(Params^[8]^), Extended(Params^[9]^), Boolean(Params^[10]^));
 end;
 
+procedure Lape_FindTextMatrix(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  with TMMLScriptThread(Params^[0]).Client do
+    PSingle(Result)^ := MFinder.FindTextMatrix(PString(Params^[1])^, PString(Params^[2])^, P2DIntegerArray(Params^[3])^, PBox(Params^[4])^);
+end;
+
+procedure Lape_FindTextColor(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  with TMMLScriptThread(Params^[0]).Client do
+    PSingle(Result)^ := MFinder.FindTextColor(PString(Params^[1])^, PString(Params^[2])^, PInt32(Params^[3])^, PInt32(Params^[4])^, PInt32(Params^[5])^, PInt32(Params^[6])^, PInt32(Params^[7])^, PInt32(Params^[8])^, PBox(Params^[9])^);
+end;
+
+procedure Lape_FindTextColorEx(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  with TMMLScriptThread(Params^[0]).Client do
+    PBoolean(Result)^ := MFinder.FindTextColor(PString(Params^[1])^, PString(Params^[2])^, PInt32(Params^[3])^, PInt32(Params^[4])^, PInt32(Params^[5])^, PInt32(Params^[6])^, PInt32(Params^[7])^, PInt32(Params^[8])^, PSingle(Params^[9])^);
+end;
+
+procedure Lape_FindText(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  with TMMLScriptThread(Params^[0]).Client do
+    PSingle(Result)^ := MFinder.FindText(PString(Params^[1])^, PString(Params^[2])^, PInt32(Params^[3])^, PInt32(Params^[4])^, PInt32(Params^[5])^, PInt32(Params^[6])^, PBox(Params^[7])^);
+end;
+
+procedure Lape_FindTextEx(const Params: PParamArray; const Result: Pointer); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  with TMMLScriptThread(Params^[0]).Client do
+    PBoolean(Result)^ := MFinder.FindText(PString(Params^[1])^, PString(Params^[2])^, PInt32(Params^[3])^, PInt32(Params^[4])^, PInt32(Params^[5])^, PInt32(Params^[6])^, PSingle(Params^[7])^);
+end;
+
 procedure Lape_Import_Finder(Compiler: TLapeCompiler; Data: Pointer);
 begin
   with Compiler do
@@ -278,6 +308,12 @@ begin
     
     addGlobalMethod('function FindTemplate(Templ: TMufasaBitmap; out x, y: Int32; Formula: ETMFormula; xs,ys,xe,ye: Int32; MinMatch: Extended; DynamicAdjust: Boolean = True): Boolean', @Lape_FindTemplate, Data);
     addGlobalMethod('function FindTemplateEx(Templ: TMufasaBitmap; out TPA: TPointArray; Formula: ETMFormula; xs,ys,xe,ye: Int32; MinMatch: Extended; DynamicAdjust: Boolean = True): Boolean', @Lape_FindTemplateEx, Data);
+
+    addGlobalMethod('function FindTextMatrix(Text, Font: String; constref Matrix: T2DIntegerArray; out Bounds: TBox): Single;', @Lape_FindTextMatrix, Data);
+    addGlobalMethod('function FindTextColor(Text, Font: String; Color, Tolerance: Int32; X1, Y1, X2, Y2: Int32; out Bounds: TBox): Single; overload;', @Lape_FindTextColor, Data);
+    addGlobalMethod('function FindTextColor(Text, Font: String; Color, Tolerance: Int32; X1, Y1, X2, Y2: Int32; MinMatch: Single = 1): Boolean; overload;', @Lape_FindTextColorEx, Data);
+    addGlobalMethod('function FindText(Text, Font: String; X1, Y1, X2, Y2: Int32; out Bounds: TBox): Single; overload;', @Lape_FindText, Data);
+    addGlobalMethod('function FindText(Text, Font: String; X1, Y1, X2, Y2: Int32; MinMatch: Single = 1): Boolean; overload;', @Lape_FindTextEx, Data);
   end;
 end;
 

--- a/Units/MMLAddon/imports/script_import_system.pas
+++ b/Units/MMLAddon/imports/script_import_system.pas
@@ -101,6 +101,8 @@ begin
     addGlobalType('Int32', 'TColor');
     addGlobalType('UInt32', 'DWord');
 
+    addGlobalType('array of TIntegerArray', 'TIntegerMatrix');
+
   //template matching & misc float matrix
     addGlobalType('array of Single', 'TSingleArray');
     addGlobalType('array of TSingleArray', 'TSingleMatrix');

--- a/Units/MMLCore/iomanager/simba.iomanager.pas
+++ b/Units/MMLCore/iomanager/simba.iomanager.pas
@@ -46,6 +46,7 @@ type
     function GetColor(X, Y: Int32): Int32;
     function CopyData(X, Y, Width, Height: Int32): PRGB32;
     function ReturnData(X, Y, Width, Height: Int32): TRetData;
+    function ReturnMatrix(X, Y, Width, Height: Int32): TIntegerMatrix;
     procedure FreeReturnData;
 
     procedure GetDimensions(out Width, Height: Int32);
@@ -298,6 +299,11 @@ end;
 function TIOManager.ReturnData(X, Y, Width, Height: Int32): TRetData;
 begin
   Result := FImage.ReturnData(X, Y, Width, Height);
+end;
+
+function TIOManager.ReturnMatrix(X, Y, Width, Height: Int32): TIntegerMatrix;
+begin
+  Result := FImage.ReturnMatrix(X, Y, Width, Height);
 end;
 
 procedure TIOManager.FreeReturnData;

--- a/Units/MMLCore/iomanager/simba.target.pas
+++ b/Units/MMLCore/iomanager/simba.target.pas
@@ -68,6 +68,7 @@ type
     function GetColor(X, Y: Int32): Int32; virtual;
     function CopyData(X, Y, Width, Height: Int32): PRGB32; virtual;
     function ReturnData(X, Y, Width, Height: Int32): TRetData; virtual;
+    function ReturnMatrix(X, Y, Width, Height: Int32): TIntegerMatrix; virtual;
     procedure FreeReturnData; virtual;
 
     // Mouse
@@ -168,6 +169,37 @@ end;
 function TTarget.ReturnData(X, Y, Width, Height: Int32): TRetData;
 begin
   raise Exception.Create('ReturnData not available for this target');
+end;
+
+function TTarget.ReturnMatrix(X, Y, Width, Height: Int32): TIntegerMatrix;
+var
+  Data: TRetData;
+  Ptr: PRGB32;
+  Upper: PtrUInt;
+begin
+  Result := Default(TIntegerMatrix);
+
+  Data := ReturnData(X, Y, Width, Height);
+
+  if Data <> NullReturnData then
+  begin
+    Ptr := Data.Ptr;
+
+    // Clear alpha
+    Upper := PtrUInt(@Ptr[Width * Height - 1]);
+    while PtrUInt(Ptr) <= Upper do
+    begin
+      Ptr^.A := 0;
+
+      Inc(Ptr);
+    end;
+
+    SetLength(Result, Height, Width);
+    for Y := 0 to Height - 1 do
+      Move(Data.Ptr[Y * Data.RowLen], Result[Y, 0], Width * SizeOf(TRGB32));
+  end;
+
+  FreeReturnData();
 end;
 
 procedure TTarget.FreeReturnData;

--- a/Units/MMLCore/iomanager/simba.target_linux.pas
+++ b/Units/MMLCore/iomanager/simba.target_linux.pas
@@ -189,10 +189,8 @@ begin
       Result.Ptr := PRGB32(FImage^.Data);
       Result.IncPtrWith := 0;
       Result.RowLen := Width;
-    end else
-      Result := NullReturnData;
-  end else
-    Result := NullReturnData;
+    end;
+  end;
 end;
 
 procedure TWindowTarget.FreeReturnData;

--- a/Units/MMLCore/mufasatypes.pas
+++ b/Units/MMLCore/mufasatypes.pas
@@ -142,6 +142,9 @@ type
   PSingleMatrix = ^TSingleMatrix;
   TSingleMatrix = array of TSingleArray;
 
+  PIntegerMatrix = ^TIntegerMatrix;
+  TIntegerMatrix = array of TIntegerArray;
+
   ETMFormula  = (TM_CCORR, TM_CCORR_NORMED, TM_CCOEFF, TM_CCOEFF_NORMED, TM_SQDIFF, TM_SQDIFF_NORMED);
   EComparator = (__LT__, __GT__, __EQ__, __LE__, __GE__, __NE__);
 

--- a/Units/MMLCore/ocrutil.pas
+++ b/Units/MMLCore/ocrutil.pas
@@ -44,6 +44,7 @@ type
   TocrGlyphMetric = record
     xoff,yoff: integer; { xoff and yoff (only on the left side, afaik
                           correspond to l and t (see InitOCR) }
+    bottom: integer;
     width,height: integer;
     index: integer; //stores the internal TocrData index for this char
     { Index is never used }
@@ -328,6 +329,7 @@ begin
     { These are not changed by the loop }
     result.ascii[ord(ascii)].width:= masks[i].width;
     result.ascii[ord(ascii)].height:= masks[i].height;
+    result.ascii[ord(ascii)].bottom := masks[i].b;
 
     { Done }
     result.ascii[ord(ascii)].inited:= true;


### PR DESCRIPTION
Added methods to find basic text. This isn't OCR, think of it as making a bitmap of the text and searching for that. (Requires a perfect font set)

```pascal
const
  FONT_NAME = 'SmallChars07';

var
  BMP: Int32;

// No color - works as long as text is a constant color
function TestOne: Single;
var
  Bounds: TBox;
begin
  DrawTextBitmap(BMP, 'Test One', FONT_NAME, Point(10, 10), False, $0000FF);
  Result := FindText('Test One', FONT_NAME, 0, 0, 99, 99, Bounds);
  RectangleBitmapEx(BMP, Bounds, $00FF00, 0.30);
end;

// No color with noise - works as long as text is a constant color
function TestTwo: Single;
var
  Bounds: TBox;
begin
  DrawTextBitmap(BMP, 'Test Two', FONT_NAME, Point(10, 30), False, $0000FF);
  DrawTextBitmap(BMP, '/', FONT_NAME, Point(40, 30), False, $0000FF);
  Result := FindText(' Two', FONT_NAME, 0, 0, 99, 99, Bounds);
  RectangleBitmapEx(BMP, Bounds, $00FF00, 0.30);
end;

// Test using color & tolerance
function TestThree: Single;
var
  Bounds: TBox;
begin
  DrawTextBitmap(BMP, 'Test Three', FONT_NAME, Point(10, 50), False, $000000);
  DrawTextBitmap(BMP, 'T', FONT_NAME, Point(10, 50), False, $00000F);
  Result := FindTextColor('Test', FONT_NAME, $000000, 50, 0, 0, 99, 99, Bounds);
  RectangleBitmapEx(BMP, Bounds, $00FF00, 0.30);
end;

begin
  BMP := CreateBitmap(100, 100);
  FastDrawClear(BMP, $FFFFFF);
  SetTargetBitmap(BMP);

  WriteLn('Test One: ', TestOne()); // 1
  WriteLn('Test One: ', TestTwo());  // 0.94
  WriteLn('Test One: ', TestThree()); // 1

  StretchBitmapResize(BMP, 300, 300);
  ShowBitmap(BMP);
  FreeBitmap(BMP);
end.                               
```
![img](https://i.imgur.com/kyPHkXV.png)
