### PR TITLE
Linux: Use a new Display instance for each thread.

### DIFF
--- a/Projects/Simba/Simba.lpi
+++ b/Projects/Simba/Simba.lpi
@@ -97,7 +97,7 @@
         <PackageName Value="LCL"/>
       </Item3>
     </RequiredPackages>
-    <Units Count="13">
+    <Units Count="14">
       <Unit0>
         <Filename Value="Simba.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -184,6 +184,10 @@
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="ACA"/>
       </Unit12>
+      <Unit13>
+        <Filename Value="../../Units/Linux/simba.xlib_display.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit13>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/Units/Linux/simba.xlib.pas
+++ b/Units/Linux/simba.xlib.pas
@@ -170,7 +170,6 @@ type
   end;
 
 var
-  XInitThreads: function: TStatus; cdecl;
   XGetWindowAttributes: function(para1:PDisplay; para2:TWindow; para3:PXWindowAttributes):TStatus; cdecl;
   XFlush: function(para1: PDisplay): cint; cdecl;
   XTranslateCoordinates: function(ADisplay:PDisplay; ASrcWindow:TWindow; ADestWindow:TWindow; ASrcX:cint; ASrcY:cint;ADestXReturn:Pcint; ADestYReturn:Pcint; AChildReturn:PWindow):TBool; cdecl;
@@ -248,7 +247,6 @@ begin
   if (X11 = nil) then
     raise Exception.Create('Error loading X11');
 
-  Pointer(XInitThreads) := dlsym(X11, 'XInitThreads');
   Pointer(XGetWindowAttributes) := dlsym(X11, 'XGetWindowAttributes');
   Pointer(XFlush) := dlsym(X11, 'XFlush');
   Pointer(XTranslateCoordinates) := dlsym(X11, 'XTranslateCoordinates');
@@ -276,7 +274,6 @@ begin
   Pointer(XSendEvent) := dlsym(X11, 'XSendEvent');
   Pointer(XSync) := dlsym(X11, 'XSync');
 
-  XInitThreads();
   XSetErrorHandler(@ErrorHandler);
 end;
 

--- a/Units/Linux/simba.xlib_display.pas
+++ b/Units/Linux/simba.xlib_display.pas
@@ -1,0 +1,55 @@
+unit simba.xlib_display;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  classes, sysutils,
+  simba.xlib;
+
+function GetDisplay(Name: String = ''): PDisplay;
+
+implementation
+
+threadvar
+  Display: PDisplay;
+
+function GetDisplay(Name: String = ''): PDisplay;
+begin
+  if (Display = nil) then
+  begin
+    WriteLn('Opening XDisplay for thread ', GetCurrentThreadID());
+
+    Display := XOpenDisplay(PChar(Name));
+    if (Display = nil) then
+      raise Exception.Create('Unable to open a new display');
+  end;
+
+  Result := Display;
+end;
+
+procedure CloseDisplay;
+begin
+  if (Display <> nil) then
+  begin
+    WriteLn('Closing XDisplay for thread ', GetCurrentThreadID());
+
+    XCloseDisplay(Display);
+  end;
+end;
+
+var
+  MemoryManager: TMemoryManager;
+
+initialization
+  GetMemoryManager(MemoryManager);
+  MemoryManager.DoneThread := @CloseDisplay;
+  SetMemoryManager(MemoryManager);
+
+finalization
+  if (Display <> nil) then
+    XCloseDisplay(Display);
+
+end.
+

--- a/Units/Linux/simba.xlib_helpers.pas
+++ b/Units/Linux/simba.xlib_helpers.pas
@@ -23,9 +23,6 @@ procedure XSetActiveWindow(Display: PDisplay; Window: TWindow);
 function XGetActiveWindow(Display: PDisplay): TWindow;
 function XGetChildren(Display: PDisplay; Window: TWindow; Recursive: Boolean): TWindowArray;
 
-var
-  DefaultDisplay: PDisplay;
-
 implementation
 
 uses
@@ -355,8 +352,7 @@ begin
   Result := XKeySymToKeyCode(Display, Symbol);
 end;
 
-function XGetChildren(Display: PDisplay; Window: TWindow; Recursive: Boolean
-  ): TWindowArray;
+function XGetChildren(Display: PDisplay; Window: TWindow; Recursive: Boolean): TWindowArray;
 
   procedure GetChildren(Window: TWindow);
   var
@@ -366,7 +362,7 @@ function XGetChildren(Display: PDisplay; Window: TWindow; Recursive: Boolean
   begin
     if (Window > 0) then
     begin
-      if XQueryTree(DefaultDisplay, Window, Root, Parent, Children, Count) then
+      if XQueryTree(Display, Window, Root, Parent, Children, Count) then
       begin
         for i := 0 to High(Children) do
         begin
@@ -385,14 +381,6 @@ begin
 
   GetChildren(Window);
 end;
-
-initialization
-  DefaultDisplay := XOpenDisplay(nil);
-  if (DefaultDisplay = nil) then
-    raise Exception.Create('Error opening default display');
-
-finalization
-  XCloseDisplay(DefaultDisplay);
 
 end.
 

--- a/Units/MMLAddon/imports/classes/MML/lpxml.pas
+++ b/Units/MMLAddon/imports/classes/MML/lpxml.pas
@@ -257,6 +257,11 @@ begin
   PVerySimpleXml(Params^[0])^.LoadFromStream(PStream(Params^[1])^);
 end;
 
+procedure TVerySimpleXml_LoadFromString(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PVerySimpleXml(Params^[0])^.LoadFromString(PlpString(Params^[1])^);
+end;
+
 //procedure SaveToStream(const Stream: TStream);
 procedure TVerySimpleXml_SaveToStream(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
@@ -267,6 +272,11 @@ end;
 procedure TVerySimpleXml_SaveToFile(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
 begin
   PVerySimpleXml(Params^[0])^.SaveToFile(PlpString(Params^[1])^);
+end;
+
+procedure TVerySimpleXml_SaveToString(const Params: PParamArray); {$IFDEF Lape_CDECL}cdecl;{$ENDIF}
+begin
+  PVerySimpleXml(Params^[0])^.SaveToString(PlpString(Params^[1])^);
 end;
 
 //Read: property Root: TXMLNode read GetRoot write SetRoot;
@@ -323,8 +333,10 @@ begin
     addGlobalFunc('procedure TXml.Clear();', @TVerySimpleXml_Clear);
     addGlobalFunc('procedure TXml.LoadFromFile(const FileName: String);', @TVerySimpleXml_LoadFromFile);
     addGlobalFunc('procedure TXml.LoadFromStream(const Stream: TStream);', @TVerySimpleXml_LoadFromStream);
+    addGlobalFunc('procedure TXml.LoadFromString(const Str: String);', @TVerySimpleXml_LoadFromString);
     addGlobalFunc('procedure TXml.SaveToStream(const Stream: TStream);', @TVerySimpleXml_SaveToStream);
     addGlobalFunc('procedure TXml.SaveToFile(const FileName: String);', @TVerySimpleXml_SaveToFile);
+    addGlobalFunc('procedure TXml.SaveToString(var Str: String);', @TVerySimpleXml_SaveToString);
     addClassVar('TXml', 'Root', 'TXMLNode', @TVerySimpleXml_Root_Read, @TVerySimpleXml_Root_Write);
     addClassVar('TXml', 'Header', 'TXMLNode', @TVerySimpleXml_Header_Read, @TVerySimpleXml_Header_Write);
     addClassVar('TXml', 'Ident', 'string', @TVerySimpleXml_Ident_Read, @TVerySimpleXml_Ident_Write);

--- a/Units/MMLAddon/imports/script_import_system.pas
+++ b/Units/MMLAddon/imports/script_import_system.pas
@@ -103,6 +103,8 @@ begin
 
     addGlobalType('array of TIntegerArray', 'TIntegerMatrix');
 
+    addGlobalVar(LineEnding, 'LineEnding').isConstant := True;
+
   //template matching & misc float matrix
     addGlobalType('array of Single', 'TSingleArray');
     addGlobalType('array of TSingleArray', 'TSingleMatrix');

--- a/Units/MMLAddon/oswindow/oswindow_linux.inc
+++ b/Units/MMLAddon/oswindow/oswindow_linux.inc
@@ -2,18 +2,18 @@
 
 uses
   x, baseunix,
-  simba.xlib, simba.xlib_helpers;
+  simba.xlib, simba.xlib_helpers, simba.xlib_display;
 
 function TOSWindow_Helper.IsValid: Boolean;
 var
   Attributes: TXWindowAttributes;
 begin
-  Result := XGetWindowAttributes(DefaultDisplay, Self, @Attributes) <> 0;
+  Result := XGetWindowAttributes(GetDisplay(), Self, @Attributes) <> 0;
 end;
 
 function TOSWindow_Helper.IsActive: Boolean;
 begin
-  Result := XGetRootWindow(DefaultDisplay, XGetActiveWindow(DefaultDisplay)) = XGetRootWindow(DefaultDisplay, Self);
+  Result := XGetRootWindow(GetDisplay(), XGetActiveWindow(GetDisplay())) = XGetRootWindow(GetDisplay(), Self);
 end;
 
 function TOSWindow_Helper.IsActive(Time: Int32): Boolean;
@@ -34,27 +34,27 @@ end;
 
 function TOSWindow_Helper.IsVisible: Boolean;
 begin
-  Result := XHasWindowProperty(DefaultDisplay, XGetRootWindow(DefaultDisplay, Self), 'WM_STATE');
+  Result := XHasWindowProperty(GetDisplay(), XGetRootWindow(GetDisplay(), Self), 'WM_STATE');
 end;
 
 function TOSWindow_Helper.GetPID: UInt32;
 begin
-  Result := XGetWindowProperty(DefaultDisplay, XGetRootWindow(DefaultDisplay, Self), XInternAtom(DefaultDisplay, PChar('_NET_WM_PID'), False));
+  Result := XGetWindowProperty(GetDisplay(), XGetRootWindow(GetDisplay(), Self), XInternAtom(GetDisplay(), PChar('_NET_WM_PID'), False));
 end;
 
 function TOSWindow_Helper.GetRootWindow: TOSWindow;
 begin
-  Result := XGetRootWindow(DefaultDisplay, Self);
+  Result := XGetRootWindow(GetDisplay(), Self);
 end;
 
 function TOSWindow_Helper.GetClassName: WideString;
 begin
-  Result := XGetWindowClass(DefaultDisplay, Self);
+  Result := XGetWindowClass(GetDisplay(), Self);
 end;
 
 function TOSWindow_Helper.GetTitle: WideString;
 begin
-  Result := XGetWindowTitle(DefaultDisplay, Self);
+  Result := XGetWindowTitle(GetDisplay(), Self);
 end;
 
 function TOSWindow_Helper.GetBounds(out Bounds: TBox): Boolean;
@@ -63,8 +63,8 @@ var
   X, Y: Int32;
   Attributes: TXWindowAttributes;
 begin
-  Result := (XGetWindowAttributes(DefaultDisplay, Self, @Attributes) <> 0) and
-            (XTranslateCoordinates(DefaultDisplay, Self, Attributes.Root, -Attributes.Border_Width, -Attributes.Border_Width, @X, @Y, @Child) <> 0);
+  Result := (XGetWindowAttributes(GetDisplay(), Self, @Attributes) <> 0) and
+            (XTranslateCoordinates(GetDisplay(), Self, Attributes.Root, -Attributes.Border_Width, -Attributes.Border_Width, @X, @Y, @Child) <> 0);
 
   if Result then
   begin
@@ -88,18 +88,18 @@ end;
 
 function TOSWindow_Helper.GetChildren(Recursive: Boolean): TOSWindowArray;
 begin
-  Result := XGetChildren(DefaultDisplay, Self, Recursive);
+  Result := XGetChildren(GetDisplay(), Self, Recursive);
 end;
 
 procedure TOSWindow_Helper.SetBounds(Bounds: TBox);
 begin
-  XMoveResizeWindow(DefaultDisplay, Self, Bounds.X1, Bounds.Y1, Bounds.X2 - Bounds.X1, Bounds.Y2 - Bounds.Y1);
-  XSync(DefaultDisplay, 0);
+  XMoveResizeWindow(GetDisplay(), Self, Bounds.X1, Bounds.Y1, Bounds.X2 - Bounds.X1, Bounds.Y2 - Bounds.Y1);
+  XSync(GetDisplay(), 0);
 end;
 
 function TOSWindow_Helper.Activate: Boolean;
 begin
-  XSetActiveWindow(DefaultDisplay, Self.GetRootWindow());
+  XSetActiveWindow(GetDisplay(), Self.GetRootWindow());
 
   Result := Self.IsActive(1000);
 end;
@@ -113,7 +113,7 @@ function GetWindows: TOSWindowArray;
 var
   Window: TOSWindow;
 begin
-  Window := XDefaultRootWindow(DefaultDisplay);
+  Window := XDefaultRootWindow(GetDisplay());
 
   Result := Window.GetChildren();
 end;
@@ -134,12 +134,12 @@ end;
 
 function GetActiveWindow: TOSWindow;
 begin
-  Result := XGetActiveWindow(DefaultDisplay);
+  Result := XGetActiveWindow(GetDisplay());
 end;
 
 function GetDesktopWindow: TOSWindow;
 begin
-  Result := XDefaultRootWindow(DefaultDisplay);
+  Result := XDefaultRootWindow(GetDisplay());
 end;
 
 function GetTopWindows: TOSWindowArray;
@@ -153,7 +153,7 @@ function GetTopWindows: TOSWindowArray;
 
     if (not Result) then
     begin
-      Windows := XGetChildren(DefaultDisplay, Window, False);
+      Windows := XGetChildren(GetDisplay(), Window, False);
 
       for i := High(Windows) downto 0 do
       begin
@@ -170,7 +170,7 @@ var
 begin
   SetLength(Result, 0);
 
-  Windows := XGetChildren(DefaultDisplay, GetDesktopWindow, FAlse);
+  Windows := XGetChildren(GetDisplay(), GetDesktopWindow, FAlse);
   for i := High(Windows) downto 0 do
     if IsVisible(Windows[i]) then
     begin

--- a/Units/MMLAddon/uxml.pas
+++ b/Units/MMLAddon/uxml.pas
@@ -126,7 +126,10 @@ type
     procedure LoadFromFile(const FileName: String);
     // Load XML for a stream
     procedure LoadFromStream(const Stream: TStream);
+    // Load XML from string
+    procedure LoadFromString(const Str: String);
     // Encoding is specified in Header-Node
+    procedure SaveToString(var Str: String);
     procedure SaveToStream(const Stream: TStream);
     procedure SaveToFile(const FileName: String);
     property Root: TXMLNode read GetRoot write SetRoot;
@@ -272,6 +275,19 @@ begin
   Lines.LoadFromStream(Stream);
   Parse;
   Lines.Clear;
+end;
+
+procedure TVerySimpleXml.LoadFromString(const Str: String);
+var
+  Stream: TStringStream;
+begin
+  Stream := TStringStream.Create(Str);
+
+  try
+    LoadFromStream(Stream);
+  finally
+    Stream.Free();
+  end;
 end;
 
 procedure TVerySimpleXml.Parse;
@@ -509,6 +525,21 @@ begin
 
   Lines.SaveToStream(Stream);
   Lines.Free;
+end;
+
+procedure TVerySimpleXml.SaveToString(var Str: String);
+var
+  Stream: TStringStream;
+begin
+  Stream := TStringStream.Create(Str);
+
+  try
+    SaveToStream(Stream);
+
+    Str := Stream.DataString;
+  finally
+    Stream.Free();
+  end;
 end;
 
 procedure TVerySimpleXml.Walk(Lines: TStringList; Prefix: String;

--- a/Units/MMLAddon/windowselector/windowselector_linux.inc
+++ b/Units/MMLAddon/windowselector/windowselector_linux.inc
@@ -1,7 +1,7 @@
 {&MainUnit windowselector.pas}
 
 uses
-  x, simba.xlib, simba.xlib_helpers;
+  x, simba.xlib, simba.xlib_helpers, simba.xlib_display;
 
 function TMWindowSelector.Drag: TOSWindow;
 type
@@ -60,7 +60,7 @@ begin
     BuildTree(Trees[i], Windows[i]);
 
   repeat
-    XQueryPointer(DefaultDisplay, GetDesktopWindow(), @Root, @Child, @RootX, @RootY, @X, @Y, @Mask);
+    XQueryPointer(GetDisplay(), GetDesktopWindow(), @Root, @Child, @RootX, @RootY, @X, @Y, @Mask);
 
     Window := 0;
     for i := 0 to High(Trees) do

--- a/Units/MMLCore/fontloader.pas
+++ b/Units/MMLCore/fontloader.pas
@@ -248,8 +248,6 @@ begin
   if (Screen.Fonts.IndexOf(SysFont.Name) = -1) then
     Exit(False);
 
-  mDebugLn('Loading system font "' + SysFont.Name + '"');
-
   Mufasa := TMufasaBitmap.Create();
   BMP := TBitmap.Create();
 
@@ -264,15 +262,22 @@ begin
 
       for i := 1 to 255 do
       begin
-        GetTextSize(Chr(i), W, H);
+        GetTextSize(UnicodeString(Chr(i)), W, H);
 
         if (W > 0) and (H > 0) then
         begin
+          SetLength(Masks, Length(Masks) + 1);
+
           BMP.SetSize(W, H);
           TextOut(0, 0, Chr(i));
           Mufasa.LoadFromTBitmap(BMP);
-          SetLength(Masks, Length(Masks) + 1);
+
+          {$IFDEF LINUX} // :| GTK2 always renders anti aliased.
+          Mufasa.ThresholdAdaptive(0, 255, False, TM_MinMax, -100);
+          Masks[High(Masks)] := LoadGlyphMask(Mufasa, True, Chr(i));
+          {$ELSE}
           Masks[High(Masks)] := LoadGlyphMask(Mufasa, False, Chr(i));
+          {$ENDIF}
         end;
       end;
     end;


### PR DESCRIPTION
`XInitThreads` wasn't doing its job. So `GetDisplay` returns a display for the current thread and is automatically managed.