### PR TITLE
first pass at history - small bug still

### DIFF
--- a/Source/Simba.lpi
+++ b/Source/Simba.lpi
@@ -469,7 +469,7 @@
         <PackageName Value="LCL"/>
       </Item5>
     </RequiredPackages>
-    <Units Count="83">
+    <Units Count="84">
       <Unit0>
         <Filename Value="Simba.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -859,6 +859,10 @@
         <Filename Value="script/imports/simba.import_timing.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit82>
+      <Unit83>
+        <Filename Value="ide/simba.form_tabs_history.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit83>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/Source/ide/simba.form_tabs_history.pas
+++ b/Source/ide/simba.form_tabs_history.pas
@@ -1,0 +1,228 @@
+﻿unit simba.form_tabs_history;
+
+{$i simba.inc}
+
+interface
+uses
+  Classes, SysUtils, Math, LazLogger,
+  simba.ide_editor, simba.ide_tab, simba.containers;
+
+type
+  TSimbaScriptTabHistory = class
+  strict private
+    type
+      THistoryPoint = class
+        Tab    : TSimbaScriptTab;
+        Caret  : TPoint;
+      end;
+      THistoryList = specialize TSimbaObjectList<THistoryPoint>;
+  strict private
+    FIndex    : Integer;       // 1-based “next slot”; 0 means empty
+    FHistory  : THistoryList;
+    FMaxDepth : Integer;
+
+    function  CreateHistoryPoint(Tab: TSimbaScriptTab; x, y: Integer): THistoryPoint;
+    procedure PruneIfNeeded;
+    procedure DumpState(const msg: String);
+  public
+    FSilent   : Boolean;
+    property MaxDepth: Integer read FMaxDepth write FMaxDepth;
+
+    procedure PushFromEditor(Tab: TSimbaScriptTab; CaretXY: TPoint);
+    procedure Clear(Tab: TSimbaScriptTab);
+    procedure GoBack;
+    procedure GoForward;
+
+    constructor Create;
+    destructor  Destroy; override;
+  end;
+
+var
+  SimbaScriptTabHistory: TSimbaScriptTabHistory;
+
+implementation
+uses simba.base, simba.form_tabs;
+
+{ ───── helpers ───── }
+function TSimbaScriptTabHistory.CreateHistoryPoint(Tab: TSimbaScriptTab; x, y: Integer): THistoryPoint;
+begin
+  DebugLn('TSimbaScriptTabHistory.MakePoint');
+  Result := THistoryPoint.Create;
+  Result.Tab := Tab;
+  Result.Caret := Point(x, y);
+end;
+
+procedure TSimbaScriptTabHistory.DumpState(const Msg: String);
+var
+  i      : Integer;
+  capStr : String;
+begin
+  DebugLn('│  State @ ' + Msg +
+          '  Index=' + IntToStr(FIndex) +
+          '  Count=' + IntToStr(FHistory.Count));
+
+  for i := 0 to FHistory.Count-1 do
+  begin
+    if Assigned(FHistory[i].Tab) then
+      capStr := FHistory[i].Tab.Caption
+    else
+      capStr := '<nil-tab>';
+
+    DebugLn(Format('│  %2d%s %s (%d,%d)',
+                   [i+1,
+                    IfThen(i+1 = FIndex, ' ►', ''),
+                    capStr,
+                    FHistory[i].Caret.X,
+                    FHistory[i].Caret.Y]));
+  end;
+end;
+
+
+procedure TSimbaScriptTabHistory.PruneIfNeeded;
+begin
+  if (FMaxDepth > 0) and (FHistory.Count > FMaxDepth) then
+  begin
+    DebugLn(['PruneIfNeeded – trimming to ', FMaxDepth]);
+    while FHistory.Count > FMaxDepth do
+      FHistory.Delete(0);
+    FIndex := EnsureRange(FIndex, 0, FHistory.Count);
+    DumpState('Prune');
+  end;
+end;
+
+procedure TSimbaScriptTabHistory.PushFromEditor(Tab: TSimbaScriptTab; CaretXY: TPoint);
+var
+  Pt: THistoryPoint;
+begin
+  DebugLn('TSimbaScriptTabHistory.PushFromEditor');
+  Pt := CreateHistoryPoint(Tab, CaretXY.X, CaretXY.Y);
+  DebugLn(Format('TSimbaScriptTabHistory.PushFromEditor pt %d, %d', [pt.Caret.X, pt.Caret.Y]));
+
+  { ignore tiny moves in the same file }
+  if (FHistory.Count > 0) and (FIndex > 0) then
+    with FHistory[FIndex-1] do
+      if (Tab = Pt.Tab) and (Abs(Caret.Y - Pt.Caret.Y) < 2) then
+        Exit;                     // nothing added, nothing deleted
+
+  DebugLn('TSimbaScriptTabHistory.PushFromEditor deduped');
+
+  { if we were in the middle of the list … }
+  if FIndex < FHistory.Count then
+  begin
+    with FHistory[FIndex] do
+      { same file and same LINE counts as the same forward point }
+      if (Tab = Pt.Tab) and (Caret.Y = Pt.Caret.Y) then
+      begin
+        Inc(FIndex);      // just move forward
+        Exit;             // keep the rest of the forward stack
+      end
+      else
+      begin
+        { different location → start a new branch }
+        while FHistory.Count > FIndex do
+          FHistory.Delete(FHistory.Count - 1);
+      end;
+  end;
+
+  FHistory.Add(Pt);
+  Inc(FIndex);
+  DumpState('Push');
+  PruneIfNeeded;
+end;
+
+procedure TSimbaScriptTabHistory.Clear(Tab: TSimbaScriptTab);
+var
+  i: Integer;
+begin
+  for i := FHistory.Count-1 downto 0 do
+    if FHistory[i].Tab = Tab then
+    begin
+      if i < FIndex then Dec(FIndex);
+      FHistory.Delete(i);
+    end;
+  DumpState('Clear');
+end;
+
+procedure TSimbaScriptTabHistory.GoBack;
+begin
+  try
+    DebugLn('GoBack');
+    if FIndex <= 1 then Exit;
+
+    FSilent := True;
+
+    repeat
+      Dec(FIndex);
+    until (FIndex = 0) or
+          (FHistory[FIndex-1].Caret.Y <> FHistory[FIndex].Caret.Y) or
+          (FHistory[FIndex-1].Tab     <> FHistory[FIndex].Tab);
+
+    if FIndex = 0 then FIndex := 1;          // safety
+
+    DumpState('Back → '+IntToStr(FIndex));
+
+    with FHistory[FIndex-1] do
+    begin
+      Tab.Show;
+      Tab.Editor.CaretXY := Caret;
+      Tab.Editor.TopLine := Caret.Y - (Tab.Editor.LinesInWindow div 2);
+      Tab.Editor.EnsureCursorPosVisible;
+    end;
+  finally
+    FSilent := False;
+  end;
+end;
+
+procedure TSimbaScriptTabHistory.GoForward;
+begin
+  DebugLn('GoForward');
+  if FIndex >= FHistory.Count then Exit;
+
+  repeat
+    Inc(FIndex);
+  until (FIndex >= FHistory.Count) or
+        (FHistory[FIndex-1].Caret.Y <> FHistory[FIndex-2].Caret.Y) or
+        (FHistory[FIndex-1].Tab     <> FHistory[FIndex-2].Tab);
+
+  if FIndex > FHistory.Count then FIndex := FHistory.Count; // safety
+
+  DumpState('Forward → '+IntToStr(FIndex));
+
+  with FHistory[FIndex-1] do
+  begin
+    Tab.Show;
+    Tab.Editor.CaretXY := Caret;
+    Tab.Editor.TopLine := Caret.Y - (Tab.Editor.LinesInWindow div 2);
+    Tab.Editor.EnsureCursorPosVisible;
+  end;
+end;
+
+{ ───── lifecycle ───── }
+constructor TSimbaScriptTabHistory.Create;
+begin
+  inherited Create;
+  DebugLn('TSimbaScriptTabHistory.Create');
+  FHistory  := THistoryList.Create(True);
+  FIndex    := 0;
+  FMaxDepth := 128;
+  FSilent   := False;
+end;
+
+destructor TSimbaScriptTabHistory.Destroy;
+begin
+  DumpState('Destroy');
+  FHistory.Free;
+  inherited Destroy;
+end;
+
+initialization
+  DebugLn('simba.form_tabs_history – initialization');
+  SimbaScriptTabHistory := TSimbaScriptTabHistory.Create;
+
+finalization
+  DebugLn('simba.form_tabs_history – finalization');
+  SimbaScriptTabHistory.Free;
+  SimbaScriptTabHistory := nil;
+
+end.
+

--- a/Source/ide/simba.form_tabs_history.pas
+++ b/Source/ide/simba.form_tabs_history.pas
@@ -101,7 +101,7 @@ begin
   { ignore tiny moves in the same file }
   if (FHistory.Count > 0) and (FIndex > 0) then
     with FHistory[FIndex-1] do
-      if (Tab = Pt.Tab) and (Abs(Caret.Y - Pt.Caret.Y) < 2) then
+      if (Tab = Pt.Tab) and (Abs(Caret.Y - Pt.Caret.Y) < 15) then
         Exit;                     // nothing added, nothing deleted
 
   DebugLn('TSimbaScriptTabHistory.PushFromEditor deduped');

--- a/Source/ide/simba.ide_editor.pas
+++ b/Source/ide/simba.ide_editor.pas
@@ -14,7 +14,7 @@ uses
   SynEdit, SynEditTypes, SynGutterLineOverview, SynEditMouseCmds, SynEditMiscClasses, SynEditKeyCmds, SynEditHighlighter, SynEditMarkupCtrlMouseLink, SynEditMarkupHighAll,
   simba.base, simba.settings,
   simba.ide_editor_completionbox, simba.ide_editor_paramhint, simba.ide_editor_attributes,
-  simba.ide_editor_modifiedlinegutter, simba.component_synedit;
+  simba.ide_editor_modifiedlinegutter, simba.component_synedit, simba.ide_editor_history;
 
 type
   TSimbaEditorFileNameEvent = function(Sender: TObject): String of object;
@@ -527,6 +527,7 @@ begin
   TSimbaEditorPlugin_DocGenerator.Create(Self);
   TSimbaEditorPlugin_CommentBlock.Create(Self);
   TSimbaEditorPlugin_MouseWheelZoom.Create(Self);
+  TSimbaEditorPlugin_History.Create(Self);
   TSimbaCodeComplete.Create(Self);
 
   FAttributes := TSimbaEditor_Attributes.Create(Self);

--- a/Source/ide/simba.ide_editor_history.pas
+++ b/Source/ide/simba.ide_editor_history.pas
@@ -20,6 +20,7 @@ type
   protected
     procedure DoEditorAdded(Value: TCustomSynEdit); override;
     function DoMouseAction(AnAction: TSynEditMouseAction; var AnInfo: TSynEditMouseActionInfo): Boolean;
+    procedure CaretStatus(Sender: TObject; Changes: TSynStatusChanges);
   public
     class var EditorCommandForward: TSynEditorCommand;
     class var EditorCommandBack: TSynEditorCommand;
@@ -29,39 +30,66 @@ type
 implementation
 
 uses
-  simba.settings;
+  SynEditTypes, simba.ide_editor,
+  simba.ide_utils, simba.form_tabs_history, simba.ide_tab, simba.base, simba.form_tabs;
+
+class constructor TSimbaEditorPlugin_History.Create;
+begin
+  DebugLn('TSimbaEditorPlugin_History.Create');
+  EditorCommandForward := AllocatePluginKeyRange(1);
+  EditorCommandBack    := AllocatePluginKeyRange(1);
+end;
+
+{ caret-move hook }
+procedure TSimbaEditorPlugin_History.CaretStatus(Sender: TObject; Changes: TSynStatusChanges);
+var
+  Tab: TSimbaScriptTab;
+  Ed: TSimbaEditor;
+begin
+  DebugLn('TSimbaEditorPlugin_History.CaretStatus');
+  if SimbaScriptTabHistory.FSilent
+     then Exit;      // ignore Back/Forward moves
+  if (scCaretX in Changes) or (scCaretY in Changes) then
+  begin
+    Ed := TSimbaEditor(Sender);
+    if (Ed.CaretX = 1) and (Ed.CaretY = 1) then
+    begin
+      DebugLn('Since CaretXY = [1, 1] not adding to history');
+      Exit;
+    end;
+    DebugLn(Sender.ToString());
+    Tab := GetSimbaActiveTab();
+    SimbaScriptTabHistory.PushFromEditor(Tab, Ed.CaretXY);     // de-dup inside history
+  end;
+end;
 
 procedure TSimbaEditorPlugin_History.DoEditorAdded(Value: TCustomSynEdit);
 begin
+  DebugLn('TSimbaEditorPlugin_History.DoEditorAdded');
   inherited DoEditorAdded(Value);
 
-  {
+   Value.MouseActions.AddCommand(EditorCommandForward, False,
+     LazSynEditMouseCmdsTypes.mbExtra2, ccSingle, cdDown, [], []);
+   Value.MouseActions.AddCommand(EditorCommandBack, False,
+     LazSynEditMouseCmdsTypes.mbExtra1, ccSingle, cdDown, [], []);
+
   Value.RegisterMouseActionExecHandler(@DoMouseAction);
-  Value.MouseActions.AddCommand(EditorCommandForward, False, LazSynEditMouseCmdsTypes.mbExtra2, ccSingle, cdDown, [], []);
-  Value.MouseActions.AddCommand(EditorCommandBack, False, LazSynEditMouseCmdsTypes.mbExtra1, ccSingle, cdDown, [], []);
-  }
+
+  DebugLn('Registering CaretStatus');
+  Value.RegisterStatusChangedHandler(@CaretStatus, [scCaretX, scCaretY]);
 end;
 
 function TSimbaEditorPlugin_History.DoMouseAction(AnAction: TSynEditMouseAction; var AnInfo: TSynEditMouseActionInfo): Boolean;
 begin
-  Result := False;
-
-  {
-  if (AnAction.Command = EditorCommandForward) then
-    SimbaScriptTabHistory.GoForward()
+  DebugLn('TSimbaEditorPlugin_History.DoMouseAction');
+  if AnAction.Command = EditorCommandForward then
+    SimbaScriptTabHistory.GoForward
   else
-  if (AnAction.Command = EditorCommandBack) then
-    SimbaScriptTabHistory.GoBack();
-   }
+  if AnAction.Command = EditorCommandBack then
+    SimbaScriptTabHistory.GoBack;
 end;
 
-class constructor TSimbaEditorPlugin_History.Create;
-begin
-  {
-  EditorCommandForward := AllocatePluginKeyRange(1);
-  EditorCommandBack := AllocatePluginKeyRange(1);
-  }
-end;
+
 
 end.
 

--- a/Source/ide/simba.ide_editor_history.pas
+++ b/Source/ide/simba.ide_editor_history.pas
@@ -87,6 +87,8 @@ begin
   else
   if AnAction.Command = EditorCommandBack then
     SimbaScriptTabHistory.GoBack;
+
+  Result := False;
 end;
 
 


### PR DESCRIPTION
Adding a forward/back button history stack to Simba2k

It works pretty well, but there is a small bug - so I left debugging in if anyone wants to take a look

The bug is - if the stack looks like this:


│  1 ► mouldCrafter (14,6)
│  2     base (13,13)  

So a caret in mouldCrafter at column 14 and row 6
A caret in base at column 13, and row 13

If I ctrl + click in mouldCrafter at the same place (14, 6) which takes me to base (13, 13) it doesn't move the stack index
