### PR TITLE
rename anchors to something that makes more sense

### DIFF
--- a/Source/script/imports/lcl/simba.import_lcl_controls.pas
+++ b/Source/script/imports/lcl/simba.import_lcl_controls.pas
@@ -819,7 +819,7 @@ begin
     addGlobalType('enum(Top, Left, Right, Bottom)', 'ELazAnchorKind');
     addGlobalType('set of ELazAnchorKind', 'ELazAnchors');
 
-    addGlobalType('enum(asrTop, asrBottom, asrCenter)', 'ELazAnchorSideReference');
+    addGlobalType('enum(Start, Finish, Center)', 'ELazAnchorSideReference');
     addGlobalType('procedure(Sender: TObject; var Key: Int16; Shift: ELazShiftStates) of object', 'TLazKeyEvent', FFI_DEFAULT_ABI);
     addGlobalType('procedure(Sender: TObject; var Key: Char) of object', 'TLazKeyPressEvent', FFI_DEFAULT_ABI);
     addGlobalType('procedure(Sender: TObject; Button: ELazMouseButton; Shift: ELazShiftStates; X, Y: Integer) of object', 'TLazMouseEvent', FFI_DEFAULT_ABI);


### PR DESCRIPTION
This is an optional PR, doesn't really fix or introduce anything new, just makes anchors less confusing IMO.

Current problem:
- `asrTop` reprensents both "Top" and "Left" depending on the anchor side
- `asrBottom` reprensents both "Bottom" and "Right" depending on the anchor side
When it's meant to represent Left and Right this is very confusing, so much so that the other day I was looking into adding the missing `asrLeft` and `asrRight`.

My purposed change fixes this. Maybe my picks are not the best, but I think it would make more clear what these represent.