### PR TITLE
Update simba.form_tabs.pas: middle mouse button click action on tab

### DIFF
--- a/Source/ide/simba.form_tabs.pas
+++ b/Source/ide/simba.form_tabs.pas
@@ -259,12 +259,21 @@ begin
 end;
 
 procedure TSimbaTabsForm.FormMouseUp(Sender: TObject; Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
+var
+  Tab: TSimbaScriptTab;
 begin
+  if (Button = mbMiddle) then
+  begin
+    Tab := TSimbaScriptTab(FTabControl.GetTabAt(X, Y));
+    if Assigned(Tab) then
+      CloseTab(Tab, True);
+  end;
+
   FMouseDown := False;
 
   if (HostDockSite is TSimbaAnchorDockHostSite) then
     TSimbaAnchorDockHostSite(HostDockSite).Header.MouseUp(Button, Shift, X, Y);
-end;
+end;  
 
 procedure TSimbaTabsForm.TabPopupMenuMeasureItem(Sender: TObject; ACanvas: TCanvas; var AWidth, AHeight: Integer);
 begin


### PR DESCRIPTION
Allow middle mouse button to close tabs like modern IDE's and browsers.


https://github.com/user-attachments/assets/01493369-ba18-42e6-a00e-234714678533

