### PR TITLE
TKDPointTree support for large TPoints

### DIFF
--- a/Source/simba.container_kdpointtree.pas
+++ b/Source/simba.container_kdpointtree.pas
@@ -235,7 +235,8 @@ var
   resNode:PNode;
   procedure __nearest(node:Integer; depth:UInt8=0);
   var
-    test,dist,delta:Integer;
+    dist: Int64;
+    test,delta:Integer;
     this:PNode;
   begin
     this := @self.data[node];

--- a/Source/simba.container_kdpointtree.pas
+++ b/Source/simba.container_kdpointtree.pas
@@ -231,7 +231,7 @@ end;
 
 function TKDPointTree.RawNearest(pt:TPoint; notEqual:Boolean=False): PNode;
 var
-  resDist:Integer;
+  resDist:Int64;
   resNode:PNode;
   procedure __nearest(node:Integer; depth:UInt8=0);
   var


### PR DESCRIPTION
Had some help from slacky.

I'm not sure if you'll want to merge this, but I would say it doesn't make sense to have a `TKDPointTree` that only works with `TPoint` if their `X` and `Y` are below a certain value.