### PR TITLE
make Grow/Erode use same neighbour amount; fix Erode double-peel per iteration

### DIFF
--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1190,7 +1190,7 @@ begin
   QueueA.Clear();
   for Y := 0 to B.Y2-1 do
     for X := 0 to B.X2-1 do
-      if Matrix[Y, X] = 1 then
+      if Matrix[Y, X] > 0 then
         QueueA.Add(X + B.X1, Y + B.Y1);
   Result := QueueA.ToArray(False);
 end;

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1111,7 +1111,7 @@ end;
 function TPointArrayHelper.Erode(Iterations: Integer): TPointArray;
 var
   I, J, X, Y: Integer;
-  Matrix, Queued: TBooleanMatrix;
+  Matrix, Enqueued: TBooleanMatrix;
   QueueA, QueueB: TSimbaPointBuffer;
   face: TPointArray;
   pt: TPoint;
@@ -1129,7 +1129,7 @@ begin
   B.Y2 := (B.Y2 - B.Y1) + Iterations + 1;
 
   Matrix.SetSize(B.X2, B.Y2);
-  SetLength(Queued, B.Y2, B.X2);
+  SetLength(Enqueued, B.Y2, B.X2);
 
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
@@ -1141,9 +1141,9 @@ begin
   for i := 0 to High(Edges) do
   begin
     pt := Edges[i];
-    if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
+    if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
     begin
-      Queued[pt.y][pt.x] := True;
+      Enqueued[pt.y][pt.x] := True;
       QueueA.Add(pt);
     end;
   end;
@@ -1161,9 +1161,9 @@ begin
           for I:=0 to 7 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
+            if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
             begin
-              Queued[pt.y][pt.x] := True;
+              Enqueued[pt.y][pt.x] := True;
               QueueB.Add(pt);
             end;
           end;
@@ -1177,9 +1177,9 @@ begin
           for I:=0 to 7 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
+            if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
             begin
-              Queued[pt.y][pt.x] := True;
+              Enqueued[pt.y][pt.x] := True;
               QueueA.Add(pt);
             end;
           end;

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1111,7 +1111,7 @@ end;
 function TPointArrayHelper.Erode(Iterations: Integer): TPointArray;
 var
   I, J, X, Y: Integer;
-  Matrix, Enqueued: TBooleanMatrix;
+  Matrix: TByteMatrix; // 0 = removed, 1 = filled, 2 = enqueued
   QueueA, QueueB: TSimbaPointBuffer;
   face: TPointArray;
   pt: TPoint;
@@ -1129,9 +1129,8 @@ begin
   B.Y2 := (B.Y2 - B.Y1) + Iterations + 1;
 
   Matrix.SetSize(B.X2, B.Y2);
-  Enqueued.SetSize(B.X2, B.Y2);
   for I:=0 to High(Self) do
-    Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
+    Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := 1;
 
   SetLength(face, 8);
 
@@ -1140,9 +1139,9 @@ begin
   for I:=0 to High(Edges) do
   begin
     pt := Edges[I];
-    if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
+    if Matrix[pt.y][pt.x] = 1 then
     begin
-      Enqueued[pt.y][pt.x] := True;
+      Matrix[pt.y][pt.x] := 2;
       QueueA.Add(pt);
     end;
   end;
@@ -1155,14 +1154,15 @@ begin
         while (QueueA.Count > 0) do
         begin
           pt := QueueA.Pop;
-          Matrix[pt.y][pt.x] := False;
+          Matrix[pt.y][pt.x] := 0;
+
           GetAdjacent8(face, pt);
           for I:=0 to 7 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
+            if Matrix[pt.y][pt.x] = 1 then
             begin
-              Enqueued[pt.y][pt.x] := True;
+              Matrix[pt.y][pt.x] := 2;
               QueueB.Add(pt);
             end;
           end;
@@ -1171,14 +1171,14 @@ begin
         while (QueueB.Count > 0) do
         begin
           pt := QueueB.Pop;
-          Matrix[pt.y][pt.x] := False;
+          Matrix[pt.y][pt.x] := 0;
           GetAdjacent8(face, pt);
           for I:=0 to 7 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
+            if Matrix[pt.y][pt.x] = 1 then
             begin
-              Enqueued[pt.y][pt.x] := True;
+              Matrix[pt.y][pt.x] := 2;
               QueueA.Add(pt);
             end;
           end;
@@ -1190,7 +1190,7 @@ begin
   QueueA.Clear();
   for Y := 0 to B.Y2-1 do
     for X := 0 to B.X2-1 do
-      if Matrix[Y, X] then
+      if Matrix[Y, X] = 1 then
         QueueA.Add(X + B.X1, Y + B.Y1);
   Result := QueueA.ToArray(False);
 end;

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1133,14 +1133,14 @@ begin
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
 
-  SetLength(face, 4);
+  SetLength(face, 8);
 
   Edges := Self.Edges().Offset(-B.X1, -B.Y1);
   QueueA.Init();
   for I:=0 to High(Edges) do
   begin
     pt := Edges[I];
-    if Matrix[pt.y][pt.x] and not Enqueued[pt.y][pt.x] then
+    if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
     begin
       Enqueued[pt.y][pt.x] := True;
       QueueA.Add(pt);
@@ -1156,11 +1156,11 @@ begin
         begin
           pt := QueueA.Pop;
           Matrix[pt.y][pt.x] := False;
-          GetAdjacent4(face, pt);
-          for I:=0 to 3 do
+          GetAdjacent8(face, pt);
+          for I:=0 to 7 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] and not Enqueued[pt.y][pt.x] then
+            if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
             begin
               Enqueued[pt.y][pt.x] := True;
               QueueB.Add(pt);
@@ -1172,8 +1172,8 @@ begin
         begin
           pt := QueueB.Pop;
           Matrix[pt.y][pt.x] := False;
-          GetAdjacent4(face, pt);
-          for I:=0 to 3 do
+          GetAdjacent8(face, pt);
+          for I:=0 to 7 do
           begin
             pt := face[I];
             if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
@@ -1218,7 +1218,7 @@ begin
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
 
-  SetLength(face,4);
+  SetLength(face,8);
   QueueA.InitWith(Self.Edges().Offset(-B.X1,-B.Y1));
   QueueB.Init();
   J := 0;
@@ -1227,8 +1227,8 @@ begin
     True:
       while (QueueA.Count > 0) do
       begin
-        GetAdjacent4(face, QueueA.Pop());
-        for I:=0 to 3 do
+        GetAdjacent8(face, QueueA.Pop());
+        for I:=0 to 7 do
         begin
           pt := face[I];
           if not(Matrix[pt.y][pt.x]) then
@@ -1242,8 +1242,8 @@ begin
     False:
       while (QueueB.Count > 0) do
       begin
-        GetAdjacent4(face, QueueB.Pop());
-        for I:=0 to 3 do
+        GetAdjacent8(face, QueueB.Pop());
+        for I:=0 to 7 do
         begin
           pt := face[I];
           if not(Matrix[pt.y][pt.x]) then

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1132,8 +1132,6 @@ begin
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := 1;
 
-  SetLength(face, 8);
-
   Edges := Self.Edges().Offset(-B.X1, -B.Y1);
   QueueA.Init();
   for I:=0 to High(Edges) do
@@ -1146,6 +1144,7 @@ begin
     end;
   end;
 
+  SetLength(face, 8);
   QueueB.Init();
   J := 0;
   repeat

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1161,9 +1161,6 @@ begin
           for I:=0 to 7 do
           begin
             pt := face[I];
-            if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.X2) or (pt.y >= B.Y2) then
-              Continue;
-
             if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
             begin
               Queued[pt.y][pt.x] := True;
@@ -1180,9 +1177,6 @@ begin
           for I:=0 to 7 do
           begin
             pt := face[I];
-            if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.X2) or (pt.y >= B.Y2) then
-              Continue;
-
             if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
             begin
               Queued[pt.y][pt.x] := True;
@@ -1239,9 +1233,6 @@ begin
         for I:=0 to 7 do
         begin
           pt := face[I];
-          if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.x2) or (pt.y >= B.y2) then
-            Continue;
-
           if not(Matrix[pt.y][pt.x]) then
           begin
             Matrix[pt.y][pt.x] := True;
@@ -1258,9 +1249,6 @@ begin
         for I:=0 to 7 do
         begin
           pt := face[I];
-          if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.x2) or (pt.y >= B.y2) then
-            Continue;
-
           if not(Matrix[pt.y][pt.x]) then
           begin
             Matrix[pt.y][pt.x] := True;

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1129,19 +1129,18 @@ begin
   B.Y2 := (B.Y2 - B.Y1) + Iterations + 1;
 
   Matrix.SetSize(B.X2, B.Y2);
-  SetLength(Enqueued, B.Y2, B.X2);
-
+  Enqueued.SetSize(B.X2, B.Y2);
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
 
-  SetLength(face, 8);
+  SetLength(face, 4);
 
   Edges := Self.Edges().Offset(-B.X1, -B.Y1);
   QueueA.Init();
-  for i := 0 to High(Edges) do
+  for I:=0 to High(Edges) do
   begin
-    pt := Edges[i];
-    if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
+    pt := Edges[I];
+    if Matrix[pt.y][pt.x] and not Enqueued[pt.y][pt.x] then
     begin
       Enqueued[pt.y][pt.x] := True;
       QueueA.Add(pt);
@@ -1157,11 +1156,11 @@ begin
         begin
           pt := QueueA.Pop;
           Matrix[pt.y][pt.x] := False;
-          GetAdjacent8(face, pt);
-          for I:=0 to 7 do
+          GetAdjacent4(face, pt);
+          for I:=0 to 3 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
+            if Matrix[pt.y][pt.x] and not Enqueued[pt.y][pt.x] then
             begin
               Enqueued[pt.y][pt.x] := True;
               QueueB.Add(pt);
@@ -1173,8 +1172,8 @@ begin
         begin
           pt := QueueB.Pop;
           Matrix[pt.y][pt.x] := False;
-          GetAdjacent8(face, pt);
-          for I:=0 to 7 do
+          GetAdjacent4(face, pt);
+          for I:=0 to 3 do
           begin
             pt := face[I];
             if Matrix[pt.y][pt.x] and (not Enqueued[pt.y][pt.x]) then
@@ -1219,7 +1218,7 @@ begin
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
 
-  SetLength(face,8);
+  SetLength(face,4);
   QueueA.InitWith(Self.Edges().Offset(-B.X1,-B.Y1));
   QueueB.Init();
   J := 0;
@@ -1228,8 +1227,8 @@ begin
     True:
       while (QueueA.Count > 0) do
       begin
-        GetAdjacent8(face, QueueA.Pop());
-        for I:=0 to 7 do
+        GetAdjacent4(face, QueueA.Pop());
+        for I:=0 to 3 do
         begin
           pt := face[I];
           if not(Matrix[pt.y][pt.x]) then
@@ -1243,8 +1242,8 @@ begin
     False:
       while (QueueB.Count > 0) do
       begin
-        GetAdjacent8(face, QueueB.Pop());
-        for I:=0 to 7 do
+        GetAdjacent4(face, QueueB.Pop());
+        for I:=0 to 3 do
         begin
           pt := face[I];
           if not(Matrix[pt.y][pt.x]) then

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1228,8 +1228,7 @@ begin
     True:
       while (QueueA.Count > 0) do
       begin
-        pt := QueueA.Pop();
-        GetAdjacent8(face, pt);
+        GetAdjacent8(face, QueueA.Pop());
         for I:=0 to 7 do
         begin
           pt := face[I];
@@ -1244,8 +1243,7 @@ begin
     False:
       while (QueueB.Count > 0) do
       begin
-        pt := QueueB.Pop();
-        GetAdjacent8(face, pt);
+        GetAdjacent8(face, QueueB.Pop());
         for I:=0 to 7 do
         begin
           pt := face[I];

--- a/Source/simba.vartype_pointarray.pas
+++ b/Source/simba.vartype_pointarray.pas
@@ -1111,11 +1111,12 @@ end;
 function TPointArrayHelper.Erode(Iterations: Integer): TPointArray;
 var
   I, J, X, Y: Integer;
-  Matrix: TBooleanMatrix;
+  Matrix, Queued: TBooleanMatrix;
   QueueA, QueueB: TSimbaPointBuffer;
   face: TPointArray;
   pt: TPoint;
   B: TBox;
+  Edges: TPointArray;
 begin
   Result := Default(TPointArray);
   if (Length(Self) = 0) or (Iterations = 0) then
@@ -1128,11 +1129,25 @@ begin
   B.Y2 := (B.Y2 - B.Y1) + Iterations + 1;
 
   Matrix.SetSize(B.X2, B.Y2);
+  SetLength(Queued, B.Y2, B.X2);
+
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
 
-  SetLength(face, 4);
-  QueueA.InitWith(Self.Edges().Offset(-B.X1, -B.Y1));
+  SetLength(face, 8);
+
+  Edges := Self.Edges().Offset(-B.X1, -B.Y1);
+  QueueA.Init();
+  for i := 0 to High(Edges) do
+  begin
+    pt := Edges[i];
+    if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
+    begin
+      Queued[pt.y][pt.x] := True;
+      QueueA.Add(pt);
+    end;
+  end;
+
   QueueB.Init();
   J := 0;
   repeat
@@ -1142,30 +1157,35 @@ begin
         begin
           pt := QueueA.Pop;
           Matrix[pt.y][pt.x] := False;
-          GetAdjacent4(face, pt);
-          for I:=0 to 3 do
+          GetAdjacent8(face, pt);
+          for I:=0 to 7 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] then
+            if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.X2) or (pt.y >= B.Y2) then
+              Continue;
+
+            if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
             begin
-              Matrix[pt.y][pt.x] := False;
+              Queued[pt.y][pt.x] := True;
               QueueB.Add(pt);
             end;
           end;
         end;
-
       False:
         while (QueueB.Count > 0) do
         begin
           pt := QueueB.Pop;
           Matrix[pt.y][pt.x] := False;
-          GetAdjacent4(face, pt);
-          for I:=0 to 3 do
+          GetAdjacent8(face, pt);
+          for I:=0 to 7 do
           begin
             pt := face[I];
-            if Matrix[pt.y][pt.x] then
+            if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.X2) or (pt.y >= B.Y2) then
+              Continue;
+
+            if Matrix[pt.y][pt.x] and (not Queued[pt.y][pt.x]) then
             begin
-              Matrix[pt.y][pt.x] := False;
+              Queued[pt.y][pt.x] := True;
               QueueA.Add(pt);
             end;
           end;
@@ -1205,7 +1225,7 @@ begin
   for I:=0 to High(Self) do
     Matrix[Self[I].Y - B.Y1][Self[I].X - B.X1] := True;
 
-  SetLength(face,4);
+  SetLength(face,8);
   QueueA.InitWith(Self.Edges().Offset(-B.X1,-B.Y1));
   QueueB.Init();
   J := 0;
@@ -1214,10 +1234,14 @@ begin
     True:
       while (QueueA.Count > 0) do
       begin
-        GetAdjacent4(face, QueueA.Pop());
-        for I:=0 to 3 do
+        pt := QueueA.Pop();
+        GetAdjacent8(face, pt);
+        for I:=0 to 7 do
         begin
           pt := face[I];
+          if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.x2) or (pt.y >= B.y2) then
+            Continue;
+
           if not(Matrix[pt.y][pt.x]) then
           begin
             Matrix[pt.y][pt.x] := True;
@@ -1229,10 +1253,14 @@ begin
     False:
       while (QueueB.Count > 0) do
       begin
-        GetAdjacent4(face, QueueB.Pop());
-        for I:=0 to 3 do
+        pt := QueueB.Pop();
+        GetAdjacent8(face, pt);
+        for I:=0 to 7 do
         begin
           pt := face[I];
+          if (pt.x < 0) or (pt.y < 0) or (pt.x >= B.x2) or (pt.y >= B.y2) then
+            Continue;
+
           if not(Matrix[pt.y][pt.x]) then
           begin
             Matrix[pt.y][pt.x] := True;


### PR DESCRIPTION
### 2 fixes:
1. we weren't separating “this layer” from “next layer.”
now have two frontiers + enqueue-once.

2. grow was doing 4 neighbour and erode was 8, so there wasn't idempotency when doing grow(1).erode(1) repeatedly


my tests:
```pascal
  redTPA := MkHoleBox(5, 5); // makes a 15x15 with a 5x5 hole

  greenTPA := redTPA.Erode(1).Grow(1);
  yellowTPA := greenTPA.Erode(1).Grow(1);

  blueTPA := redTPA.Grow(1).Erode(1);
  orangeTPA := blueTPA.Grow(1).Erode(1); 
```

<img width="925" height="205" alt="image" src="https://github.com/user-attachments/assets/4e9fa37c-35c8-4199-bcc6-4dd84ca1c1c7" />

```pascal
  redTPA := MkCornerTouch(5, 5); // makes 2 5x5 squares touching at the corner

  greenTPA := redTPA.Erode(1).Grow(1);
  yellowTPA := greenTPA.Erode(1).Grow(1);

  blueTPA := redTPA.Grow(1).Erode(1);
  orangeTPA := blueTPA.Grow(1).Erode(1); 
```

<img width="797" height="148" alt="image" src="https://github.com/user-attachments/assets/787c6df3-9f00-42f1-9f57-bca652adb58c" />


