### PR TITLE
Make PathExtractNameWithoutExt a little more accurate

### DIFF
--- a/Source/simba.fs.pas
+++ b/Source/simba.fs.pas
@@ -301,7 +301,7 @@ class function TSimbaPath.PathExtractNameWithoutExt(Path: String): String;
 begin
   Result := ExtractFileName(Path);
   if '.' in Result then
-    Result := Result.Before('.');
+    Result := Result.Before(ExtractFileExt(Path));
 end;
 
 class function TSimbaPath.PathExtractExt(Path: String): String;


### PR DESCRIPTION
currently if a file has multiple periods in it then this method doesn't really work, i know kind of user error like why do i need files with periods, but it's ez fix.

this isn't perfect however if a file is named like `image.png.png` since it will choose the first `.png` and return `image` instead of `image.png` but it's slightly better than before