### PR TITLE
Enhance Simba with the power of the rainbow🌈 

### DIFF
--- a/Source/ide/simba.form_output.lfm
+++ b/Source/ide/simba.form_output.lfm
@@ -1,19 +1,18 @@
 object SimbaOutputForm: TSimbaOutputForm
   Left = 4227
-  Height = 140
+  Height = 112
   Top = 24
-  Width = 676
+  Width = 541
   Caption = 'Output'
-  DesignTimePPI = 120
+  ShowInTaskBar = stAlways
+  LCLVersion = '4.4.0.0'
   OnMouseDown = FormMouseDown
   OnMouseLeave = FormMouseLeave
   OnMouseMove = FormMouseMove
-  ShowInTaskBar = stAlways
-  LCLVersion = '3.4.0.0'
   object ContextMenu: TPopupMenu
     OnMeasureItem = ContextMenuMeasureItem
-    Left = 40
-    Top = 56
+    Left = 32
+    Top = 45
     object MenuItemCopyLine: TMenuItem
       Caption = 'Copy Line'
       OnClick = MenuItemCopyLineClick
@@ -44,7 +43,7 @@ object SimbaOutputForm: TSimbaOutputForm
   object FlushTimer: TTimer
     Interval = 500
     OnTimer = DoFlushTimerExecute
-    Left = 128
-    Top = 56
+    Left = 102
+    Top = 45
   end
 end

--- a/Source/ide/simba.form_output.pas
+++ b/Source/ide/simba.form_output.pas
@@ -135,6 +135,13 @@ type
     property OutputBox: TSimbaOutputBox read FOutputBox;
   end;
 
+type
+  PLineFlagsData = ^TLineFlagsData;
+  TLineFlagsData = record
+    Flags: EDebugLnFlags;
+    Color: TColor;
+  end;
+
 procedure TSimbaOutputTab.DoTabScriptStateChange(Sender: TObject);
 begin
   if (Sender is TSimbaScriptTab) and (TSimbaScriptTab(Sender).OutputBox = FOutputBox) then
@@ -240,19 +247,21 @@ end;
 
 procedure TSimbaOutputBox.DoSpecialLineMarkup(Sender: TObject; Line: Integer; var Special: Boolean; AMarkup: TSynSelectedColor);
 var
-  Flags: EDebugLnFlags;
+  lineData: PLineFlagsData;
 begin
-  Flags := EDebugLnFlags(Integer(PtrUInt(Lines.Objects[Line - 1])));
+  lineData := PLineFlagsData(Lines.Objects[Line - 1]);
 
-  if (([EDebugLn.YELLOW, EDebugLn.RED, EDebugLn.GREEN] * Flags) <> []) then
+  if lineData = nil then
   begin
-    if (EDebugLn.YELLOW in Flags) then AMarkup.Background := $00BFFF else
-    if (EDebugLn.RED    in Flags) then AMarkup.Background := $0000A5 else
-    if (EDebugLn.GREEN  in Flags) then AMarkup.Background := $228B22;
+    Special := False;
+    Exit;
+  end;
 
+  if EDebugLn.BACKGROUND_COLOR in lineData.Flags then
+  begin
+    AMarkup.Background := lineData.Color;
     AMarkup.BackAlpha  := 115;
     AMarkup.Foreground := clNone;
-
     Special := True;
   end else
     Special := False;
@@ -304,16 +313,22 @@ begin
 end;
 
 destructor TSimbaOutputBox.Destroy;
+var
+  i: Integer;
 begin
+  if (FBuffer <> nil) then
+  begin
+    for i := 0 to FBuffer.Count - 1 do
+      Dispose(PLineFlagsData(FBuffer.Objects[i]))
+    FreeAndNil(FBuffer);
+  end;
   if (FLock <> nil) then
     FreeAndNil(FLock);
-  if (FBuffer <> nil) then
-    FreeAndNil(FBuffer);
 
   inherited Destroy();
 end;
 
-procedure TSimbaOutputBox.GetWordBoundsAtRowCol(const XY: TPoint; out StartX, EndX: integer);
+procedure TSimbaOutputBox.GetWordBoundsAtRowCol(const XY: TPoint; out StartX, EndX: Integer);
 
   // Line 3 in function "cpuuu" in file "Untitled"
   function FindStackTrace(Line: String; var StartPos, EndPos: Integer): Boolean;
@@ -386,7 +401,7 @@ var
   Arr: TStringArray;
   I: Integer;
   Line: String;
-  Flags: EDebugLnFlags;
+  lineData: PLineData;
 begin
   Arr := S.Split(LineEnding, False);
   if (Length(Arr) = 0) then
@@ -402,9 +417,9 @@ begin
       for I := 0 to High(Arr) do
       begin
         Line  := Arr[I];
-        Flags := FlagsFromString(Line);
-
-        FBuffer.AddObject(Line, TObject(PtrUInt(Integer(Flags))));
+        New(lineData);
+        lineData^.Flags := FlagsFromString(Line, lineData^.Color);
+        FBuffer.AddObject(Line, TObject(data));
       end;
     end else
     begin
@@ -413,9 +428,9 @@ begin
       for I := 0 to High(Arr) - 1 do
       begin
         Line  := Arr[I];
-        Flags := FlagsFromString(Line);
-
-        FBuffer.AddObject(Line, TObject(PtrUInt(Integer(Flags))));
+        New(lineData);
+        lineData^.Flags := FlagsFromString(Line, lineData^.Color);
+        FBuffer.AddObject(Line, TObject(data));
       end;
     end;
 
@@ -439,7 +454,7 @@ procedure TSimbaOutputBox.Flush;
 var
   I, StartIndex: Integer;
   NeedFocus, NeedScroll: Boolean;
-  Flags: EDebugLnFlags;
+  lineData: PLineFlagsData;
 begin
   FLock.Enter();
 
@@ -451,10 +466,10 @@ begin
       StartIndex := 0;
       for I := 0 to FBuffer.Count - 1 do
       begin
-        Flags := EDebugLnFlags(Integer(PtrUInt(FBuffer.Objects[I])));
-        if (EDebugLn.CLEAR in Flags) then
+        lineData := PLineFlagsData(FBuffer.Objects[I]);
+        if (EDebugLn.CLEAR in lineData^.Flags) then
           StartIndex := I+1;
-        if (EDebugLn.FOCUS in Flags) then
+        if (EDebugLn.FOCUS in lineData^.Flags) then
           NeedFocus := True;
       end;
 
@@ -465,7 +480,10 @@ begin
       // auto scroll if already scrolled to bottom.
       NeedScroll := (Lines.Count < LinesInWindow) or ((Lines.Count + 1) = (TopLine + LinesInWindow));
       for I := StartIndex to FBuffer.Count - 1 do
-        Lines.AddObject(FBuffer[I], FBuffer.Objects[I]);
+      begin
+        lineData := PLineFlagsData(FBuffer.Objects[I]);
+        Lines.AddObject(FBuffer[I], TObject(lineData));
+      end;
 
       if NeedFocus or NeedScroll then
       begin
@@ -477,6 +495,8 @@ begin
       EndUpdate();
       Invalidate();
 
+      for I := 0 to FBuffer.Count - 1 do
+        Dispose(PLineFlagsData(FBuffer.Objects[I]));
       FBuffer.Clear();
     end;
   finally

--- a/Source/ide/simba.form_output.pas
+++ b/Source/ide/simba.form_output.pas
@@ -439,9 +439,14 @@ begin
 end;
 
 procedure TSimbaOutputBox.AddLine(Flags: EDebugLnFlags; const S: String);
+var
+  lineData: PLineFlagsData;
 begin
   FLock.Enter();
-  FBuffer.AddObject(S, TObject(PtrUInt(Integer(Flags))));
+  New(lineData);
+  lineData^.Flags := Flags;
+  lineData^.Color := $0;
+  FBuffer.AddObject(S, TObject(lineData));
   FLock.Leave();
 end;
 

--- a/Source/ide/simba.form_output.pas
+++ b/Source/ide/simba.form_output.pas
@@ -251,11 +251,12 @@ var
 begin
   lineData := PLineFlagsData(Lines.Objects[Line - 1]);
 
-  if lineData = nil then
-  begin
-    Special := False;
-    Exit;
-  end;
+  //99.99% sure there's no need to check, should never be nil
+  //if lineData = nil then
+  //begin
+  //  Special := False;
+  //  Exit;
+  //end;
 
   if EDebugLn.BACKGROUND_COLOR in lineData^.Flags then
   begin

--- a/Source/ide/simba.form_output.pas
+++ b/Source/ide/simba.form_output.pas
@@ -257,9 +257,9 @@ begin
     Exit;
   end;
 
-  if EDebugLn.BACKGROUND_COLOR in lineData.Flags then
+  if EDebugLn.BACKGROUND_COLOR in lineData^.Flags then
   begin
-    AMarkup.Background := lineData.Color;
+    AMarkup.Background := lineData^.Color;
     AMarkup.BackAlpha  := 115;
     AMarkup.Foreground := clNone;
     Special := True;
@@ -319,7 +319,7 @@ begin
   if (FBuffer <> nil) then
   begin
     for i := 0 to FBuffer.Count - 1 do
-      Dispose(PLineFlagsData(FBuffer.Objects[i]))
+      Dispose(PLineFlagsData(FBuffer.Objects[i]));
     FreeAndNil(FBuffer);
   end;
   if (FLock <> nil) then
@@ -401,7 +401,7 @@ var
   Arr: TStringArray;
   I: Integer;
   Line: String;
-  lineData: PLineData;
+  lineData: PLineFlagsData;
 begin
   Arr := S.Split(LineEnding, False);
   if (Length(Arr) = 0) then
@@ -419,7 +419,7 @@ begin
         Line  := Arr[I];
         New(lineData);
         lineData^.Flags := FlagsFromString(Line, lineData^.Color);
-        FBuffer.AddObject(Line, TObject(data));
+        FBuffer.AddObject(Line, TObject(lineData));
       end;
     end else
     begin
@@ -430,7 +430,7 @@ begin
         Line  := Arr[I];
         New(lineData);
         lineData^.Flags := FlagsFromString(Line, lineData^.Color);
-        FBuffer.AddObject(Line, TObject(data));
+        FBuffer.AddObject(Line, TObject(lineData));
       end;
     end;
 
@@ -447,7 +447,7 @@ end;
 
 procedure TSimbaOutputBox.Empty;
 begin
-  Add(FlagsToString([EDebugLn.CLEAR]) + LineEnding);
+  Add(FlagsToString([EDebugLn.CLEAR], $0) + LineEnding);
 end;
 
 procedure TSimbaOutputBox.Flush;

--- a/Source/ide/simba.ide_package_autoupdater.pas
+++ b/Source/ide/simba.ide_package_autoupdater.pas
@@ -228,7 +228,7 @@ begin
 
     if Package.HasUpdate() and Package.AutoUpdateEnabled then
     begin
-      DebugLn([EDebugLn.FOCUS, EDebugLn.YELLOW], 'Automatically updating %s', [Package.Name]);
+      DebugLn([EDebugLn.FOCUS, EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), 'Automatically updating %s', [Package.Name]);
       Sleep(750); // whatever, let above flush... TSimbaPackageInstaller directly writes to the synedit.
 
       try
@@ -247,16 +247,16 @@ begin
 
           if Install(InstallOpts) then
           begin
-            DebugLn([EDebugLn.FOCUS, EDebugLn.GREEN], 'Succesfully updated "%s"', [Package.Name]);
-            DebugLn([EDebugLn.FOCUS, EDebugLn.GREEN], 'Now at version: %s', [Package.InstalledVersion]);
+            DebugLn([EDebugLn.FOCUS, EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Succesfully updated "%s"', [Package.Name]);
+            DebugLn([EDebugLn.FOCUS, EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Now at version: %s', [Package.InstalledVersion]);
           end else
-            DebugLn([EDebugLn.FOCUS, EDebugLn.RED], 'Failed to update: %s', [Package.Name]);
+            DebugLn([EDebugLn.FOCUS, EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.RED), 'Failed to update: %s', [Package.Name]);
         finally
           Free();
         end;
       except
         on E: Exception do
-          DebugLn([EDebugLn.FOCUS, EDebugLn.RED], 'Failed to update: %s (%s)', [Package.Name, E.Message]);
+          DebugLn([EDebugLn.FOCUS, EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.RED), 'Failed to update: %s (%s)', [Package.Name, E.Message]);
       end;
     end;
   end;

--- a/Source/script/simba.script.pas
+++ b/Source/script/simba.script.pas
@@ -125,7 +125,7 @@ end;
 
 procedure TSimbaScript.DoCompilerHint(Sender: TLapeCompilerBase; Hint: lpString);
 begin
-  DebugLn([EDebugLn.YELLOW], Hint);
+  DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), Hint);
 end;
 
 procedure TSimbaScript.DoCompilerFindFile(Sender: TLapeCompiler; var FileName: lpString);

--- a/Source/script/simba.script_runner.pas
+++ b/Source/script/simba.script_runner.pas
@@ -44,7 +44,7 @@ uses
 procedure TSimbaScriptRunner.DoDebugLn(Flags: EDebugLnFlags; color: EDebugLnColor; Text: String);
 begin
   if (SimbaProcessType = ESimbaProcessType.SCRIPT_WITH_COMMUNICATION) then // Only add flags if we have communication with simba to use them
-    DebugLn(Flags, Text)
+    DebugLn(Flags, GetLineColor(color), Text)
   else
   begin
     if Application.HasOption('silent') then

--- a/Source/script/simba.script_runner.pas
+++ b/Source/script/simba.script_runner.pas
@@ -10,7 +10,7 @@ unit simba.script_runner;
 interface
 
 uses
-  Classes, SysUtils,
+  Classes, SysUtils, Graphics,
   lptypes, lpvartypes, lpmessages,
   simba.script, simba.base;
 

--- a/Source/script/simba.script_runner.pas
+++ b/Source/script/simba.script_runner.pas
@@ -47,7 +47,7 @@ begin
     DebugLn(Flags, Text)
   else
   begin
-    if Application.HasOption('silent') and (Flags * [EDebugLn.YELLOW, EDebugLn.GREEN] <> []) then
+    if Application.HasOption('silent') and (Flags * [EDebugLn.BACKGROUND_COLOR] <> []) then
       Exit;
 
     DebugLn(Text);
@@ -105,7 +105,7 @@ begin
 
     try
       if FScript.Compile() then
-        DoDebugLn([EDebugLn.GREEN], 'Succesfully compiled in %.2f milliseconds.'.Format([FScript.CompileTime]));
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Succesfully compiled in %.2f milliseconds.'.Format([FScript.CompileTime]));
     except
       on E: Exception do
       begin
@@ -119,9 +119,9 @@ begin
       FScript.Run();
 
       if (FScript.RunningTime < 10000) then
-        DoDebugLn([EDebugLn.GREEN], 'Succesfully executed in %.2f milliseconds.'.Format([FScript.RunningTime]))
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Succesfully executed in %.2f milliseconds.'.Format([FScript.RunningTime]))
       else
-        DoDebugLn([EDebugLn.GREEN], 'Succesfully executed in %s.'.Format([FormatMilliseconds(Round(FScript.RunningTime), '\[hh:mm:ss\]')]));
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Succesfully executed in %s.'.Format([FormatMilliseconds(Round(FScript.RunningTime), '\[hh:mm:ss\]')]));
     except
       on E: Exception do
         DoError(E);

--- a/Source/script/simba.script_runner.pas
+++ b/Source/script/simba.script_runner.pas
@@ -56,7 +56,7 @@ end;
 
 procedure TSimbaScriptRunner.DoCompilerHint(Sender: TLapeCompilerBase; Hint: lpString);
 begin
-  DoDebugLn([EDebugLn.YELLOW], Hint);
+  DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), Hint);
 end;
 
 procedure TSimbaScriptRunner.DoApplicationTerminate(Sender: TObject);
@@ -83,15 +83,15 @@ var
 begin
   ExitCode := 1;
 
-  DoDebugLn([EDebugLn.RED, EDebugLn.FOCUS], E.Message);
+  DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], GetLineColor(EDebugLnColor.RED), E.Message);
 
   if (E is lpException) then
     with lpException(E) do
     begin
       for Line in StackTrace.Split(LineEnding) do
-        DoDebugLn([EDebugLn.RED, EDebugLn.FOCUS], Line);
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], GetLineColor(EDebugLnColor.RED), Line);
       for Line in Hint.Split(LineEnding) do
-        DoDebugLn([EDebugLn.YELLOW, EDebugLn.FOCUS], Line);
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], GetLineColor(EDebugLnColor.YELLOW), Line);
 
       if (FScript.SimbaCommunication <> nil) then
         FScript.SimbaCommunication.ScriptError(Message, DocPos.Line, DocPos.Col, DocPos.FileName);

--- a/Source/script/simba.script_runner.pas
+++ b/Source/script/simba.script_runner.pas
@@ -20,7 +20,7 @@ type
     FScript: TSimbaScript;
     FCompileOnly: Boolean;
 
-    procedure DoDebugLn(Flags: EDebugLnFlags; Text: String);
+    procedure DoDebugLn(Flags: EDebugLnFlags; bgColor: TColor; Text: String);
     procedure DoCompilerHint(Sender: TLapeCompilerBase; Hint: lpString);
 
     procedure DoApplicationTerminate(Sender: TObject);
@@ -41,14 +41,21 @@ uses
   simba.env, simba.fs, simba.datetime, simba.script_communication, simba.vartype_string,
   simba.baseclass;
 
-procedure TSimbaScriptRunner.DoDebugLn(Flags: EDebugLnFlags; Text: String);
+procedure TSimbaScriptRunner.DoDebugLn(Flags: EDebugLnFlags; bgColor: TColor; Text: String);
 begin
   if (SimbaProcessType = ESimbaProcessType.SCRIPT_WITH_COMMUNICATION) then // Only add flags if we have communication with simba to use them
     DebugLn(Flags, Text)
   else
   begin
-    if Application.HasOption('silent') and (Flags * [EDebugLn.BACKGROUND_COLOR] <> []) then
+    if Application.HasOption('silent') then
+    begin
+      if (Flags * [EDebugLn.BACKGROUND_COLOR] <> []) then
+      begin
+        if bgColor = GetLineColor(EDebugLnColor.RED) then
+           DebugLn(Text);
+      end;
       Exit;
+    end;
 
     DebugLn(Text);
   end;

--- a/Source/script/simba.script_runner.pas
+++ b/Source/script/simba.script_runner.pas
@@ -10,7 +10,7 @@ unit simba.script_runner;
 interface
 
 uses
-  Classes, SysUtils, Graphics,
+  Classes, SysUtils,
   lptypes, lpvartypes, lpmessages,
   simba.script, simba.base;
 
@@ -20,7 +20,7 @@ type
     FScript: TSimbaScript;
     FCompileOnly: Boolean;
 
-    procedure DoDebugLn(Flags: EDebugLnFlags; bgColor: TColor; Text: String);
+    procedure DoDebugLn(Flags: EDebugLnFlags; color: EDebugLnColor; Text: String);
     procedure DoCompilerHint(Sender: TLapeCompilerBase; Hint: lpString);
 
     procedure DoApplicationTerminate(Sender: TObject);
@@ -41,7 +41,7 @@ uses
   simba.env, simba.fs, simba.datetime, simba.script_communication, simba.vartype_string,
   simba.baseclass;
 
-procedure TSimbaScriptRunner.DoDebugLn(Flags: EDebugLnFlags; bgColor: TColor; Text: String);
+procedure TSimbaScriptRunner.DoDebugLn(Flags: EDebugLnFlags; color: EDebugLnColor; Text: String);
 begin
   if (SimbaProcessType = ESimbaProcessType.SCRIPT_WITH_COMMUNICATION) then // Only add flags if we have communication with simba to use them
     DebugLn(Flags, Text)
@@ -50,10 +50,8 @@ begin
     if Application.HasOption('silent') then
     begin
       if (Flags * [EDebugLn.BACKGROUND_COLOR] <> []) then
-      begin
-        if bgColor = GetLineColor(EDebugLnColor.RED) then
-           DebugLn(Text);
-      end;
+        if color = EDebugLnColor.RED then
+          DebugLn(Text);
       Exit;
     end;
 
@@ -90,15 +88,15 @@ var
 begin
   ExitCode := 1;
 
-  DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], GetLineColor(EDebugLnColor.RED), E.Message);
+  DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], EDebugLnColor.RED, E.Message);
 
   if (E is lpException) then
     with lpException(E) do
     begin
       for Line in StackTrace.Split(LineEnding) do
-        DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], GetLineColor(EDebugLnColor.RED), Line);
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], EDebugLnColor.RED, Line);
       for Line in Hint.Split(LineEnding) do
-        DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], GetLineColor(EDebugLnColor.YELLOW), Line);
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR, EDebugLn.FOCUS], EDebugLnColor.YELLOW, Line);
 
       if (FScript.SimbaCommunication <> nil) then
         FScript.SimbaCommunication.ScriptError(Message, DocPos.Line, DocPos.Col, DocPos.FileName);
@@ -112,7 +110,7 @@ begin
 
     try
       if FScript.Compile() then
-        DoDebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Succesfully compiled in %.2f milliseconds.'.Format([FScript.CompileTime]));
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR], EDebugLnColor.GREEN, 'Succesfully compiled in %.2f milliseconds.'.Format([FScript.CompileTime]));
     except
       on E: Exception do
       begin
@@ -126,9 +124,9 @@ begin
       FScript.Run();
 
       if (FScript.RunningTime < 10000) then
-        DoDebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Succesfully executed in %.2f milliseconds.'.Format([FScript.RunningTime]))
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR], EDebugLnColor.GREEN, 'Succesfully executed in %.2f milliseconds.'.Format([FScript.RunningTime]))
       else
-        DoDebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.GREEN), 'Succesfully executed in %s.'.Format([FormatMilliseconds(Round(FScript.RunningTime), '\[hh:mm:ss\]')]));
+        DoDebugLn([EDebugLn.BACKGROUND_COLOR], EDebugLnColor.GREEN, 'Succesfully executed in %s.'.Format([FormatMilliseconds(Round(FScript.RunningTime), '\[hh:mm:ss\]')]));
     except
       on E: Exception do
         DoError(E);

--- a/Source/simba.base.pas
+++ b/Source/simba.base.pas
@@ -468,24 +468,37 @@ end;
 
 function FlagsToString(const flags: EDebugLnFlags; const bgColor: TColor): String; inline;
 begin
-  Result := DebugLnFlagsHeader;
-  Result := Result + Chr(FlagsToByte(flags));
+  Result := DebugLnFlagsHeader + Chr(FlagsToByte(flags));
   if (EDebugLn.BACKGROUND_COLOR in flags) then
-    Result := Result + Chr((bgColor shr 16) and $FF) +
-                       Chr((bgColor shr 8) and $FF) +
-                       Chr(bgColor and $FF);
+    Result += Format('%.6X', [bgColor])
+  else
+    Result += '000000';
 end;
 
 function FlagsFromString(var str: String; out bgColor: TColor): EDebugLnFlags;
-  function _HexToColor(const hex: String): TColor;
+  function HexToColor(P: PChar): TColor; inline;
+  var
+    N, I: Integer;
+    Val: Char;
   begin
-    if Length(hex) = 6 then
-      Result := (StrToInt('$' + Copy(hex,1,2)) shl 16) or
-                (StrToInt('$' + Copy(hex,3,2)) shl 8)  or
-                 StrToInt('$' + Copy(hex,5,2))
-    else
-      Result := 0;
+    Result := 0;
+
+    for I := 1 to 6 do
+    begin
+      Val := P^;
+      case Val of
+        '0'..'9': N := Ord(Val) - (Ord('0'));
+        'a'..'f': N := Ord(Val) - (Ord('a') - 10);
+        'A'..'F': N := Ord(Val) - (Ord('A') - 10);
+        else
+          Exit(0);
+      end;
+      Inc(P);
+
+      Result := Result*16+N;
+    end;
   end;
+
 var
   flagsByte: Byte;
 begin
@@ -500,15 +513,14 @@ begin
     //maybe in the future... would like multi color support per line
 
     if EDebugLn.BACKGROUND_COLOR in Result then
-    begin
-      bgColor := _HexToColor(Copy(str, 4, 6));
-    end
+      bgColor := HexToColor(@Str[4])
     else
       bgColor := $0;
 
     Delete(str, 1, DebugLnFlagsHeaderLength);
   end;
 end;
+
 
 function InRange(const AValue, AMin, AMax: Integer): Boolean;
 begin

--- a/Source/simba.base.pas
+++ b/Source/simba.base.pas
@@ -456,13 +456,13 @@ end;
 
 const
   DebugLnFlagsHeader       = String(#0#0);
-  DebugLnFlagsHeaderLength = Length(DebugLnFlagsHeader) + 6;
+  DebugLnFlagsHeaderLength = Length(DebugLnFlagsHeader) + 7;
 
 function FlagsToByte(const flags: EDebugLnFlags): Byte; inline;
 begin
   Result := 0;
-  if EDebugLn.CLEAR           in flags then Result := Result or 1;
-  if EDebugLn.FOCUS           in flags then Result := Result or 2;
+  if EDebugLn.CLEAR            in flags then Result := Result or 1;
+  if EDebugLn.FOCUS            in flags then Result := Result or 2;
   if EDebugLn.BACKGROUND_COLOR in flags then Result := Result or 4;
 end;
 
@@ -477,9 +477,17 @@ begin
 end;
 
 function FlagsFromString(var str: String; out bgColor: TColor): EDebugLnFlags;
+  function _HexToColor(const hex: String): TColor;
+  begin
+    if Length(hex) = 6 then
+      Result := (StrToInt('$' + Copy(hex,1,2)) shl 16) or
+                (StrToInt('$' + Copy(hex,3,2)) shl 8)  or
+                 StrToInt('$' + Copy(hex,5,2))
+    else
+      Result := 0;
+  end;
 var
   flagsByte: Byte;
-  idx: Integer;
 begin
   Result := [];
   if (Length(Str) >= DebugLnFlagsHeaderLength) and (Str[1] = DebugLnFlagsHeader[1]) and (Str[2] = DebugLnFlagsHeader[2]) then
@@ -491,11 +499,9 @@ begin
     //if (flagsByte and 8 <> 0) then Include(Result, EDebugLn.TEXT_COLOR);
     //maybe in the future... would like multi color support per line
 
-    idx := 4;
     if EDebugLn.BACKGROUND_COLOR in Result then
     begin
-      bgColor := (Ord(Str[idx]) shl 16) or (Ord(str[idx+1]) shl 8) or Ord(str[idx+2]);
-      Inc(idx, 3);
+      bgColor := _HexToColor(Copy(str, 4, 6));
     end
     else
       bgColor := $0;

--- a/Source/simba.base.pas
+++ b/Source/simba.base.pas
@@ -298,8 +298,9 @@ procedure DebugLn(const Flags: EDebugLnFlags; bgColor: TColor; const Msg: String
 
 function GetLineColor(const color: EDebugLnColor): TColor;
 
+function FlagsToByte(const flags: EDebugLnFlags): Byte;
 function FlagsToString(const flags: EDebugLnFlags; const bgColor: TColor): String;
-function FlagsFromString(var Str: String; out bgColor: Int32): EDebugLnFlags;
+function FlagsFromString(var Str: String; out bgColor: TColor): EDebugLnFlags;
 
 function InRange(const AValue, AMin, AMax: Integer): Boolean; inline; overload;
 function InRange(const AValue, AMin, AMax: Int64): Boolean; inline; overload;
@@ -448,30 +449,34 @@ end;
 
 function GetLineColor(const color: EDebugLnColor): TColor; inline;
 const
-  DEBUG_LINE_COLORS: array [EDebugLnColor] of TColor = [
-    $00BFFF, $0000A5, $228B22
-  ];
+  DEBUG_LINE_COLORS: TColorArray = ($00BFFF, $0000A5, $228B22);
 begin
-  Result := DEBUG_LINE_COLORS[color];
+  Result := DEBUG_LINE_COLORS[Ord(color)];
 end;
 
 const
   DebugLnFlagsHeader       = String(#0#0);
   DebugLnFlagsHeaderLength = Length(DebugLnFlagsHeader) + 6;
 
+function FlagsToByte(const flags: EDebugLnFlags): Byte; inline;
+begin
+  Result := 0;
+  if EDebugLn.CLEAR           in flags then Result := Result or 1;
+  if EDebugLn.FOCUS           in flags then Result := Result or 2;
+  if EDebugLn.BACKGROUND_COLOR in flags then Result := Result or 4;
+end;
+
 function FlagsToString(const flags: EDebugLnFlags; const bgColor: TColor): String; inline;
 begin
   Result := DebugLnFlagsHeader;
-  Result := Result + Chr(Byte(flags));
+  Result := Result + Chr(FlagsToByte(flags));
   if (EDebugLn.BACKGROUND_COLOR in flags) then
-  begin
     Result := Result + Chr((bgColor shr 16) and $FF) +
                        Chr((bgColor shr 8) and $FF) +
                        Chr(bgColor and $FF);
-  end;
 end;
 
-function FlagsFromString(var str: String; out bgColor: Int32): EDebugLnFlags;
+function FlagsFromString(var str: String; out bgColor: TColor): EDebugLnFlags;
 var
   flagsByte: Byte;
   idx: Integer;

--- a/Source/simba.base.pas
+++ b/Source/simba.base.pas
@@ -279,7 +279,8 @@ type
 {$PUSH}
 {$SCOPEDENUMS ON}
 type
-  EDebugLn = (CLEAR, YELLOW, RED, GREEN, FOCUS);
+  EDebugLn = (CLEAR, FOCUS, BACKGROUND_COLOR);
+  EDebugLnColor = (YELLOW, RED, GREEN);
   EDebugLnFlags = set of EDebugLn;
 {$POP}
 
@@ -291,10 +292,14 @@ procedure Debug(const Msg: String; Args: array of const); overload;
 procedure DebugLn(const Msg: String); overload;
 procedure DebugLn(const Msg: String; Args: array of const); overload;
 procedure DebugLn(const Flags: EDebugLnFlags; const Msg: String); overload;
+procedure DebugLn(const Flags: EDebugLnFlags; bgColor: TColor; const Msg: String); overload; 
 procedure DebugLn(const Flags: EDebugLnFlags; const Msg: String; Args: array of const); overload;
+procedure DebugLn(const Flags: EDebugLnFlags; bgColor: TColor; const Msg: String; Args: array of const); overload;
 
-function FlagsToString(const Flags: EDebugLnFlags): String;
-function FlagsFromString(var Str: String): EDebugLnFlags;
+function GetLineColor(const color: EDebugLnColor): TColor;
+
+function FlagsToString(const flags: EDebugLnFlags; const bgColor: TColor): String;
+function FlagsFromString(var Str: String; out bgColor: Int32): EDebugLnFlags;
 
 function InRange(const AValue, AMin, AMax: Integer): Boolean; inline; overload;
 function InRange(const AValue, AMin, AMax: Int64): Boolean; inline; overload;
@@ -412,12 +417,22 @@ end;
 
 procedure DebugLn(const Flags: EDebugLnFlags; const Msg: String);
 begin
-  DebugLn(FlagsToString(Flags) + Msg);
+  DebugLn(FlagsToString(Flags, $0) + Msg);
+end;
+
+procedure DebugLn(const Flags: EDebugLnFlags; bgColor: TColor; const Msg: String);
+begin
+  DebugLn(FlagsToString(Flags, bgColor) + Msg);
 end;
 
 procedure DebugLn(const Flags: EDebugLnFlags; const Msg: String; Args: array of const);
 begin
-  DebugLn(FlagsToString(Flags) + Format(Msg, Args));
+  DebugLn(FlagsToString(Flags, $0) + Format(Msg, Args));
+end;
+
+procedure DebugLn(const Flags: EDebugLnFlags; bgColor: TColor; const Msg: String; Args: array of const);
+begin
+  DebugLn(FlagsToString(Flags, bgColor) + Format(Msg, Args));
 end;
 
 procedure SimbaException(Message: String; Args: array of const);
@@ -430,48 +445,58 @@ begin
   raise ESimbaException.Create(Message);
 end;
 
+
+function GetLineColor(const color: EDebugLnColor): TColor; inline;
+const
+  DEBUG_LINE_COLORS: array [EDebugLnColor] of TColor = [
+    $00BFFF, $0000A5, $228B22
+  ];
+begin
+  Result := DEBUG_LINE_COLORS[color];
+end;
+
 const
   DebugLnFlagsHeader       = String(#0#0);
   DebugLnFlagsHeaderLength = Length(DebugLnFlagsHeader) + 6;
 
-function FlagsToString(const Flags: EDebugLnFlags): String; inline;
+function FlagsToString(const flags: EDebugLnFlags; const bgColor: TColor): String; inline;
 begin
-  Result := DebugLnFlagsHeader + IntToHex(Integer(Flags), 6);
+  Result := DebugLnFlagsHeader;
+  Result := Result + Chr(Byte(flags));
+  if (EDebugLn.BACKGROUND_COLOR in flags) then
+  begin
+    Result := Result + Chr((bgColor shr 16) and $FF) +
+                       Chr((bgColor shr 8) and $FF) +
+                       Chr(bgColor and $FF);
+  end;
 end;
 
-function FlagsFromString(var Str: String): EDebugLnFlags;
-
-  function HexToInt(P: PChar): Integer; inline;
-  var
-    N, I: Integer;
-    Val: Char;
-  begin
-    Result := 0;
-
-    for I := 1 to 6 do
-    begin
-      Val := P^;
-      case Val of
-        '0'..'9': N := Ord(Val) - (Ord('0'));
-        'a'..'f': N := Ord(Val) - (Ord('a') - 10);
-        'A'..'F': N := Ord(Val) - (Ord('A') - 10);
-        else
-          Exit(0);
-      end;
-      Inc(P);
-
-      Result := Result*16+N;
-    end;
-  end;
-
+function FlagsFromString(var str: String; out bgColor: Int32): EDebugLnFlags;
+var
+  flagsByte: Byte;
+  idx: Integer;
 begin
+  Result := [];
   if (Length(Str) >= DebugLnFlagsHeaderLength) and (Str[1] = DebugLnFlagsHeader[1]) and (Str[2] = DebugLnFlagsHeader[2]) then
   begin
-    Result := EDebugLnFlags(HexToInt(@Str[3]));
+    flagsByte := Ord(str[3]);
+    if (flagsByte and 1 <> 0) then Include(Result, EDebugLn.CLEAR);
+    if (flagsByte and 2 <> 0) then Include(Result, EDebugLn.FOCUS);
+    if (flagsByte and 4 <> 0) then Include(Result, EDebugLn.BACKGROUND_COLOR);
+    //if (flagsByte and 8 <> 0) then Include(Result, EDebugLn.TEXT_COLOR);
+    //maybe in the future... would like multi color support per line
 
-    Delete(Str, 1, DebugLnFlagsHeaderLength);
-  end else
-    Result := [];
+    idx := 4;
+    if EDebugLn.BACKGROUND_COLOR in Result then
+    begin
+      bgColor := (Ord(Str[idx]) shl 16) or (Ord(str[idx+1]) shl 8) or Ord(str[idx+2]);
+      Inc(idx, 3);
+    end
+    else
+      bgColor := $0;
+
+    Delete(str, 1, DebugLnFlagsHeaderLength);
+  end;
 end;
 
 function InRange(const AValue, AMin, AMax: Integer): Boolean;

--- a/Source/simba.baseclass.pas
+++ b/Source/simba.baseclass.pas
@@ -74,7 +74,7 @@ begin
       if not TrackedObjects.First.FreeOnTerminate then
       begin
         if NeedHeader then
-          DebugLn([EDebugLn.YELLOW], 'The following objects were not freed:');
+          DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), 'The following objects were not freed:');
         NeedHeader := False;
 
         TrackedObjects.First.NotifyUnfreed();
@@ -98,7 +98,7 @@ begin
       if not TrackedThreads[I].Finished then
       begin
         if NeedHeader then
-          DebugLn([EDebugLn.YELLOW], 'The following threads were still running:');
+          DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), 'The following threads were still running:');
         NeedHeader := False;
 
         TrackedThreads[I].NotifyUnfreed();
@@ -119,7 +119,7 @@ begin
       if TrackedThreads.First.Finished and (not TrackedThreads.First.FreeOnTerminate) then
       begin
         if NeedHeader then
-          DebugLn([EDebugLn.YELLOW], 'The following threads were not freed:');
+          DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), 'The following threads were not freed:');
         NeedHeader := False;
 
         TrackedThreads.First.NotifyUnfreed();
@@ -153,7 +153,7 @@ end;
 
 procedure TSimbaBaseClass.NotifyUnfreed;
 begin
-  DebugLn([EDebugLn.YELLOW], '  ' + ClassName + ' (' + HexStr(Self) + ')' + IfThen(Name <> '', ' "' + Name + '"', ''));
+  DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), '  ' + ClassName + ' (' + HexStr(Self) + ')' + IfThen(Name <> '', ' "' + Name + '"', ''));
 end;
 
 function TSimbaBaseClass.GetName: String;
@@ -189,7 +189,7 @@ end;
 
 procedure TSimbaBaseThread.NotifyUnfreed;
 begin
-  DebugLn([EDebugLn.YELLOW], '  ' + ClassName + ' (' + HexStr(Self) + ')' + IfThen(FName <> '', ' "' + FName + '"', ''));
+  DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), '  ' + ClassName + ' (' + HexStr(Self) + ')' + IfThen(FName <> '', ' "' + FName + '"', ''));
 end;
 
 constructor TSimbaBaseThread.Create;

--- a/Source/simba.jsonparser.pas
+++ b/Source/simba.jsonparser.pas
@@ -243,7 +243,7 @@ procedure TJsonItemTracked.NotifyUnfreed;
   end;
 
 begin
-  DebugLn([EDebugLn.YELLOW], '  ' + Dump());
+  DebugLn([EDebugLn.BACKGROUND_COLOR], GetLineColor(EDebugLnColor.YELLOW), '  ' + Dump());
 end;
 
 constructor TJsonItemTracked.Create(AItem: TJSONData);


### PR DESCRIPTION
Gives full BGR output color support to Simba output (and editor I think).

I'm not sure if you would like this in Simba or not but I think it's kinda nice to have things more flexible and also extensible as I made it somewhat easy to add a few more flags in the future if we want. Speed wise, should be roughly the same as before except special strings have one extra byte.

This is also likely my biggest Simba change ever so I would appreciate it if do a good review of my changes in case I missed anything and of course, you are free to change and improve anything you don't like about it.

Here is a video preview of what this does:
https://github.com/user-attachments/assets/492e9153-5d05-480f-9d5e-2372bc909a13

One thing I was also considering was controling the "Alpha" which you have hard coded but I kinda like this tinted look.


Anyway if this is merged, I would also like to also try and give per character color inside of each line someday.
But that would be something for another day and it would be quite a different proposal as that requires iterating over the string.

My idea would be to add a TEXT_COLOR flag to know we have character colors enconded in the string and if we have that flag we iterate the string looking for #0#0'BBGGRR' and color the next characters.
But yeah, something for another day!