### PR TITLE
Feature: Live file reload

### DIFF
--- a/Source/ide/simba.form_tabs.pas
+++ b/Source/ide/simba.form_tabs.pas
@@ -89,6 +89,7 @@ type
     procedure Find;
     procedure FindNext;
     procedure FindPrevious;
+    function CheckForFileChanges: Boolean;
 
     function AddTab: TSimbaScriptTab;
     function FindTab(ID: Integer): TSimbaScriptTab;
@@ -521,6 +522,28 @@ procedure TSimbaTabsForm.FindPrevious;
 begin
   if (CurrentEditor <> nil) then
     FEditorFind.FindPrev(CurrentEditor);
+end;
+
+function TSimbaTabsForm.CheckForFileChanges: Boolean;
+var
+  Tab: TSimbaScriptTab;
+begin
+  Result := False;
+  Tab := CurrentTab;
+  if (Tab = nil) or (Tab.ScriptFileName = '') or (not FileExists(Tab.ScriptFileName)) then
+    Exit;
+
+  if (FileDateToDateTime(FileAge(Tab.ScriptFileName)) > Tab.DiskAge) then
+  begin
+    if MessageDlg('File "' + Tab.ScriptFileName + '" has changed on disk.' + sLineBreak + 'Do you want to reload it?',
+                  mtConfirmation, [mbYes, mbNo], 0) = mrYes then
+    begin
+      Tab.Load(Tab.ScriptFileName);
+      Result := True;
+    end
+    else
+      Tab.UpdateDiskAge();
+  end;
 end;
 
 function TSimbaTabsForm.AddTab: TSimbaScriptTab;

--- a/Source/ide/simba.ide_tab.pas
+++ b/Source/ide/simba.ide_tab.pas
@@ -90,7 +90,6 @@ type
 
     FOutputBox: TSimbaOutputBox;
 
-    procedure UpdateDiskAge;
     procedure LoadDefaultScript;
     procedure FindDeclarationAtCaretASync(Data: PtrInt);
 

--- a/Source/ide/simba.ide_tab.pas
+++ b/Source/ide/simba.ide_tab.pas
@@ -84,11 +84,13 @@ type
     FSavedText: String;
     FScriptFileName: String;
     FScriptTitle: String;
+    FDiskAge: TDateTime;
 
     FScriptRunner: TSimbaScriptTabRunner;
 
     FOutputBox: TSimbaOutputBox;
 
+    procedure UpdateDiskAge;
     procedure LoadDefaultScript;
     procedure FindDeclarationAtCaretASync(Data: PtrInt);
 
@@ -114,7 +116,9 @@ type
     property ScriptChanged: Boolean read GetScriptChanged;
     property Script: String read GetScript;
     property Editor: TSimbaEditor read FEditor;
+    property DiskAge: TDateTime read FDiskAge;
 
+    procedure UpdateDiskAge;
     function SaveAsDialog: String;
 
     function Save(FileName: String): Boolean;
@@ -342,6 +346,14 @@ begin
   Result := FEditor.Text <> FSavedText;
 end;
 
+procedure TSimbaScriptTab.UpdateDiskAge;
+begin
+  if (FScriptFileName <> '') and FileExists(FScriptFileName) then
+    FDiskAge := FileDateToDateTime(FileAge(FScriptFileName))
+  else
+    FDiskAge := 0;
+end;
+
 procedure TSimbaScriptTab.LoadDefaultScript;
 begin
   case SimbaSettings.Editor.DefaultScriptType.Value of
@@ -460,6 +472,7 @@ begin
     FScriptTitle := FScriptTitle.Before('.simba');
 
   Caption := FScriptTitle;
+  UpdateDiskAge();
 end;
 
 function TSimbaScriptTab.Load(FileName: String): Boolean;
@@ -490,6 +503,7 @@ begin
     FScriptTitle := FScriptTitle.Before('.simba');
 
   Caption := FScriptTitle;
+  UpdateDiskAge();
   if Result then
     SimbaIDEEvents.Notify(SimbaIDEEvent.TAB_LOADED, Self);
 end;
@@ -573,6 +587,9 @@ procedure TSimbaScriptTab.Run(Target: TWindowHandle);
 begin
   //DebugLn('TSimbaScriptTab.Run :: ' + ScriptTitle + ' ' + ScriptFileName);
 
+  if SimbaTabsForm.CheckForFileChanges() then
+    Exit;
+
   if (FScriptRunner <> nil) then
     FScriptRunner.Resume()
   else
@@ -591,6 +608,9 @@ end;
 procedure TSimbaScriptTab.Compile;
 begin
   //DebugLn('TSimbaScriptTab.Compile :: ' + ScriptTitle + ' ' + ScriptFileName);
+
+  if SimbaTabsForm.CheckForFileChanges() then
+    Exit;
 
   if (FScriptRunner = nil) then
   begin


### PR DESCRIPTION
Added a check to detect if the active script has been modified by an external editor.
  - The check is performed specifically before Run or Compile to prevent overwriting external changes with stale IDE data.
  - Prompts the user to reload the file if a mismatch is detected.



https://github.com/user-attachments/assets/792a032c-3a89-4653-852c-a8995cc7964b

