### PR TITLE
Make Linux build able to target on Wayland

### DIFF
--- a/Source/simba.fs.pas
+++ b/Source/simba.fs.pas
@@ -301,7 +301,7 @@ class function TSimbaPath.PathExtractNameWithoutExt(Path: String): String;
 begin
   Result := ExtractFileName(Path);
   if '.' in Result then
-    Result := Result.Before('.');
+    Result := Result.Before(ExtractFileExt(Path));
 end;
 
 class function TSimbaPath.PathExtractExt(Path: String): String;

--- a/Source/simba.nativeinterface_linux.pas
+++ b/Source/simba.nativeinterface_linux.pas
@@ -663,7 +663,14 @@ end;
 
 function TSimbaNativeInterface_Linux.GetWindowAtCursor(Exclude: TWindowHandleArray): TWindowHandle;
 
-  function ShouldReturnWindow(Window: TWindow): Boolean;
+  function NormalizeWindow(Window: TWindow): TWindow;
+  begin
+    Result := GetRootWindow(Window);
+    if (Result = 0) then
+      Result := Window;
+  end;
+
+  function IsUsableWindow(Window: TWindow): Boolean;
   var
     B: TBox;
   begin
@@ -675,31 +682,78 @@ function TSimbaNativeInterface_Linux.GetWindowAtCursor(Exclude: TWindowHandleArr
   end;
 
 var
-  Root, Child: TWindow;
+  Root, Child, Current: TWindow;
   x_root, y_root, x, y: Integer;
   mask: UInt32;
   I: Integer;
   Windows: array[UInt8] of TWindow;
   WindowCount: Integer;
+  RawCandidate, NormalizedCandidate: TWindow;
 begin
   Result := 0;
   WindowCount := 0;
 
-  SimbaXLib.XQueryPointer(GetDesktopWindow(), @Root, @Child, @x_root, @y_root, @x, @y, @mask);
-  while SimbaXLib.XQueryPointer(Child, @Root, @Child, @x_root, @y_root, @x, @y, @mask) do
+  if not SimbaXLib.XQueryPointer(GetDesktopWindow(), @Root, @Child, @x_root, @y_root, @x, @y, @mask) then
+  begin
+    DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: initial XQueryPointer failed');
+    Exit(0);
+  end;
+
+  DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: root=%d child=%d', [Root, Child]);
+
+  if (Child = 0) then
+  begin
+    DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: child is 0');
+    Exit(0);
+  end;
+
+  Current := Child;
+
+  // IMPORTANT: include the first child returned from the root query
+  Windows[WindowCount] := Current;
+  Inc(WindowCount);
+
+  while SimbaXLib.XQueryPointer(Current, @Root, @Child, @x_root, @y_root, @x, @y, @mask) do
   begin
     if (Child = 0) then
       Break;
-    Windows[WindowCount] := Child;
+
+    DebugLn([EDebugLn.FOCUS], '  descended child=%d', [Child]);
+
+    Current := Child;
+    Windows[WindowCount] := Current;
     Inc(WindowCount);
+
     if (WindowCount > High(Windows)) then
-      Exit;
+      Break;
   end;
 
-  // now go back until we find something worthwhile
+  DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: candidate count=%d', [WindowCount]);
+
   for I := WindowCount - 1 downto 0 do
-    if ShouldReturnWindow(Windows[I]) then
-      Exit(Windows[I])
+  begin
+    RawCandidate := Windows[I];
+    DebugLn([EDebugLn.FOCUS], '  trying raw=%d title="%s" class="%s"',
+      [RawCandidate, GetWindowTitle(RawCandidate), GetWindowClass(RawCandidate)]);
+
+    if IsUsableWindow(RawCandidate) then
+    begin
+      DebugLn([EDebugLn.FOCUS], '  returning raw=%d', [RawCandidate]);
+      Exit(RawCandidate);
+    end;
+
+    NormalizedCandidate := NormalizeWindow(RawCandidate);
+    DebugLn([EDebugLn.FOCUS], '  trying normalized=%d title="%s" class="%s"',
+      [NormalizedCandidate, GetWindowTitle(NormalizedCandidate), GetWindowClass(NormalizedCandidate)]);
+
+    if IsUsableWindow(NormalizedCandidate) then
+    begin
+      DebugLn([EDebugLn.FOCUS], '  returning normalized=%d', [NormalizedCandidate]);
+      Exit(NormalizedCandidate);
+    end;
+  end;
+
+  DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: returning 0');
 end;
 
 function TSimbaNativeInterface_Linux.GetDesktopWindow: TWindowHandle;
@@ -725,8 +779,14 @@ begin
 end;
 
 function TSimbaNativeInterface_Linux.IsWindowVisible(Window: TWindowHandle): Boolean;
+var
+  Attr: TXWindowAttributes;
 begin
-  Result := HasWindowProperty(GetRootWindow(Window), SimbaXLib.WM_STATE);
+  if (Window = 0) then
+    Exit;
+
+  if SimbaXLib.XGetWindowAttributes(Window, @Attr) then
+    Result := Attr.map_state = IsViewable;
 end;
 
 function TSimbaNativeInterface_Linux.GetWindowPID(Window: TWindowHandle): Integer;

--- a/Source/simba.nativeinterface_linux.pas
+++ b/Source/simba.nativeinterface_linux.pas
@@ -695,15 +695,11 @@ begin
 
   if not SimbaXLib.XQueryPointer(GetDesktopWindow(), @Root, @Child, @x_root, @y_root, @x, @y, @mask) then
   begin
-    DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: initial XQueryPointer failed');
     Exit(0);
   end;
 
-  DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: root=%d child=%d', [Root, Child]);
-
   if (Child = 0) then
   begin
-    DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: child is 0');
     Exit(0);
   end;
 
@@ -718,8 +714,6 @@ begin
     if (Child = 0) then
       Break;
 
-    DebugLn([EDebugLn.FOCUS], '  descended child=%d', [Child]);
-
     Current := Child;
     Windows[WindowCount] := Current;
     Inc(WindowCount);
@@ -728,32 +722,21 @@ begin
       Break;
   end;
 
-  DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: candidate count=%d', [WindowCount]);
-
   for I := WindowCount - 1 downto 0 do
   begin
     RawCandidate := Windows[I];
-    DebugLn([EDebugLn.FOCUS], '  trying raw=%d title="%s" class="%s"',
-      [RawCandidate, GetWindowTitle(RawCandidate), GetWindowClass(RawCandidate)]);
 
     if IsUsableWindow(RawCandidate) then
     begin
-      DebugLn([EDebugLn.FOCUS], '  returning raw=%d', [RawCandidate]);
       Exit(RawCandidate);
     end;
 
     NormalizedCandidate := NormalizeWindow(RawCandidate);
-    DebugLn([EDebugLn.FOCUS], '  trying normalized=%d title="%s" class="%s"',
-      [NormalizedCandidate, GetWindowTitle(NormalizedCandidate), GetWindowClass(NormalizedCandidate)]);
-
     if IsUsableWindow(NormalizedCandidate) then
     begin
-      DebugLn([EDebugLn.FOCUS], '  returning normalized=%d', [NormalizedCandidate]);
       Exit(NormalizedCandidate);
     end;
   end;
-
-  DebugLn([EDebugLn.FOCUS], 'GetWindowAtCursor: returning 0');
 end;
 
 function TSimbaNativeInterface_Linux.GetDesktopWindow: TWindowHandle;


### PR DESCRIPTION
Something changed between Simba1400 and Simba2000 where targetting doesn't work on Wayland

```
Window Selected: 0
Xlib error suppressed: BadWindow
Xlib error suppressed: BadWindow
 - Dimensions: 0x0
 - Title: ""
 - Class: ""
 - PID: 0 (32 bit)
 - Executable: ""
Xlib error suppressed: BadWindow 
```
https://github.com/user-attachments/assets/437dac7a-be70-4476-ac74-ef163b6f6afe

With these changes targetting works on Wayland now:

https://github.com/user-attachments/assets/ad5d7972-1655-41c8-a8a3-2de283e370ef



