### PR TITLE
Fix FileReadBytes silently truncating files larger than 16 MiB

### DIFF
--- a/Source/simba.fs.pas
+++ b/Source/simba.fs.pas
@@ -20,7 +20,7 @@ const
 type
   TSimbaFile = class
   private
-    class function DoFileRead(const FileName: String; Len, Offset: Integer; out Bytes: TByteArray): Boolean;
+    class function DoFileRead(const FileName: String; Len, Offset: Int64; out Bytes: TByteArray): Boolean;
     class function DoFileWrite(const FileName: String; const Bytes: TByteArray; Seek: TSeekOrigin; Offset: Integer): Boolean;
   public
     // Read/Write String
@@ -372,7 +372,7 @@ begin
   Result := False;
 end;
 
-class function TSimbaFile.DoFileRead(const FileName: String; Len, Offset: Integer; out Bytes: TByteArray): Boolean;
+class function TSimbaFile.DoFileRead(const FileName: String; Len, Offset: Int64; out Bytes: TByteArray): Boolean;
 var
   Stream: TFileStream;
 begin
@@ -383,7 +383,7 @@ begin
   try
     Stream := TFileStream.Create(FileName, fmOpenRead or fmShareDenyNone);
     if (Len = -1) then
-      Len := $FFFFFF;
+      Len := High(Int64);
     SetLength(Bytes, Min(Len, Stream.Size - Offset));
     if (Length(Bytes) > 0) then
     begin


### PR DESCRIPTION
## Summary

`TSimbaFile.DoFileRead`'s "read whole file" path (`Len = -1`, used by `FileRead` and `FileReadBytes`) replaced the sentinel with `$FFFFFF` = **16,777,215 bytes** (16 MiB - 1). Almost certainly a typo. Any whole-file read of a file larger than 16 MiB silently returned a **truncated** buffer with no error.

Per maintainer feedback, fixed properly with **Int64** rather than just bumping the constant: `Len`/`Offset` are now `Int64` and the whole-file sentinel uses `High(Int64)`, so a read is bounded only by the actual file size — no arbitrary 32-bit (or 2 GiB) cap. `DoFileRead` is **private**, so the public API and the scripting ABI are unchanged.

## Diff

```diff
-    class function DoFileRead(const FileName: String; Len, Offset: Integer; out Bytes: TByteArray): Boolean;
+    class function DoFileRead(const FileName: String; Len, Offset: Int64; out Bytes: TByteArray): Boolean;
```
```diff
     Stream := TFileStream.Create(FileName, fmOpenRead or fmShareDenyNone);
     if (Len = -1) then
-      Len := $FFFFFF;
+      Len := High(Int64);
     SetLength(Bytes, Min(Len, Stream.Size - Offset));
```

## Repro (downstream symptom)

WaspLib's `TRSMapLoader` graph cache for a sufficiently large area produces a >16 MiB compressed `walkableclusters.txt` (in my case 26.7 MiB → 116 MiB decompressed). On script restart:

1. `FileReadBytes('walkableclusters.txt')` read only 16 MiB of the 26.7 MiB file — silently truncated.
2. `DecompressBytes(ZLIB, …)` was handed a partial zlib stream and produced a partial output buffer.
3. `T2DPointArray.CreateFromBytes(…)` walked the length-prefixed buffer, ran off the end, and raised `Runtime error: "buffer error"`.

Verified the file on disk is well-formed (Python `zlib.decompress` round-trips to 116 MB); after the fix `FileReadBytes` returns the full 26,737,409 bytes and `CreateFromBytes` deserializes without error.

## Notes

- `FileRead` (string) shares `DoFileRead`, so it had the same 16 MiB truncation for text files — also fixed.
- `FileReadBytesEx`/`FileReadEx` still take `Integer` `Start`/`Stop` (explicit ranges); not touched here since the reported bug is the whole-file path. Can be widened separately if desired.

## Test plan
- [x] WaspLib script hitting the GraphFromCache path on a large map — crashed before, works after.
- [x] Builds clean on Win64.
- [ ] Untested on Linux/macOS (platform-independent change).