### PR TITLE
fix: re-introducing the removed TTarget target properties

### DIFF
--- a/Source/script/imports/simba.import_target.pas
+++ b/Source/script/imports/simba.import_target.pas
@@ -24,6 +24,7 @@ type
   PTargetEvent = ^ETargetEvent;
   PQuad = ^TQuad;
   PSimbaTargetOptions = ^TSimbaTargetOptions;
+  PPluginTargetData = ^TPluginTargetData;
 
 (*
 Target
@@ -250,7 +251,7 @@ TTarget.SetImage
 procedure TTarget.SetImage(TImage: TImage);
 ```
 
-Sets the TSimbaImage as a target.
+Sets the TImage as a target.
 
 ```{note}
 Ownership of the image is taken. It will be freed whenever the target is changed or freed
@@ -323,6 +324,56 @@ procedure _LapeTarget_SetPlugin2(const Params: PParamArray); LAPE_WRAPPER_CALLIN
 begin
   PLapeObjectTarget(Params^[0])^^.SetPlugin(PString(Params^[1])^, PString(Params^[2])^, TSimbaExternalCanvas(Params^[3]^));
 end;
+
+
+(*
+TTarget.WindowTarget
+--------------------
+```
+property TTarget.WindowTarget: TWindowHandle;
+```
+*)
+procedure _LapeTarget_GetWindowTarget(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
+begin
+  PWindowHandle(Result)^ := PLapeObjectTarget(Params^[0])^^.GetWindowTarget();
+end;
+
+(*
+TTarget.ImageTarget
+-------------------
+```
+property TTarget.ImageTarget: TImage;
+```
+*)
+procedure _LapeTarget_GetImageTarget(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
+begin
+  PLapeObjectImage(Result)^^ := PLapeObjectTarget(Params^[0])^^.GetImageTarget();
+end;
+
+(*
+TTarget.EIOSTarget
+------------------
+```
+property TTarget.EIOSTarget: TPluginTargetData;
+```
+*)
+procedure _LapeTarget_GetEIOSTarget(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
+begin
+  PPluginTargetData(Result)^ := PLapeObjectTarget(Params^[0])^^.GetEIOSTarget();
+end;
+
+(*
+TTarget.PluginTarget
+--------------------
+```
+property TTarget.PluginTarget: TPluginTargetData;
+```
+*)
+procedure _LapeTarget_GetPluginTarget(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
+begin
+  PPluginTargetData(Result)^ := PLapeObjectTarget(Params^[0])^^.GetPluginTarget();
+end;
+
 
 (*
 TTarget.FreezeImage
@@ -410,6 +461,7 @@ procedure _LapeTarget_Focus(const Params: PParamArray; const Result: Pointer); L
 begin
   PBoolean(Result)^ := PLapeObjectTarget(Params^[0])^^.Focus();
 end;
+
 
 (*
 TTarget.ToString
@@ -1210,6 +1262,21 @@ begin
     addGlobalFunc('procedure TTarget.SetEIOS(Plugin, Args: String)', @_LapeTarget_SetEIOS);
     addGlobalFunc('procedure TTarget.SetPlugin(Plugin, Args: String); overload', @_LapeTarget_SetPlugin1);
     addGlobalFunc('procedure TTarget.SetPlugin(Plugin, Args: String; out Canvas: TExternalCanvas); overload', @_LapeTarget_SetPlugin2);
+
+    addGlobalType(
+      [
+        'record',
+        '  Filename: String;',
+        '  Target: Pointer;',
+        'end;'
+      ], 'TPluginTargetData'
+    );
+
+
+    addProperty('TTarget', 'WindowTarget', 'TWindowHandle', @_LapeTarget_GetWindowTarget);
+    addProperty('TTarget', 'ImageTarget', 'TImage', @_LapeTarget_GetImageTarget);
+    addProperty('TTarget', 'EIOSTarget', 'TPluginTargetData', @_LapeTarget_GetEIOSTarget);
+    addProperty('TTarget', 'PluginTarget', 'TPluginTargetData', @_LapeTarget_GetPluginTarget);
 
     addGlobalFunc('procedure TTarget.FreezeImage(Bounds: TBox = [-1,-1,-1,-1]);', @_LapeTarget_FreezeImage);
     addGlobalFunc('procedure TTarget.UnFreezeImage;', @_LapeTarget_UnFreezeImage);

--- a/Source/simba.target.pas
+++ b/Source/simba.target.pas
@@ -31,6 +31,11 @@ const
   TargetName: array[ESimbaTargetKind] of String = ('NONE', 'IMAGE', 'WINDOW', 'EIOS', 'PLUGIN');
 
 type
+  TPluginTargetData = record
+    Filename: String;
+    Target: Pointer;
+  end;
+
   TSimbaTargetMethods = record
     GetDimensions: procedure(Target: Pointer; out W, H: Integer);
     GetImageData: function(Target: Pointer; X, Y, Width, Height: Integer; out Data: PColorBGRA; out DataWidth: Integer): Boolean;
@@ -194,6 +199,11 @@ type
     procedure SetEIOS(FileName, Args: String);
     procedure SetPlugin(FileName, Args: String); overload;
     procedure SetPlugin(FileName, Args: String; out DebugImage: TSimbaExternalCanvas); overload;
+
+    function GetWindowTarget(): TWindowHandle;
+    function GetImageTarget(): TSimbaImage;
+    function GetEIOSTarget(): TPluginTargetData;
+    function GetPluginTarget(): TPluginTargetData;
 
     function GetImageDataAsImage(var ABounds: TBox; out Image: TSimbaImage): Boolean;
     function GetImageData(var ABounds: TBox; out Data: PColorBGRA; out DataWidth: Integer): Boolean;
@@ -1185,6 +1195,48 @@ begin
   TargetChanged();
 end;
 
+
+function TSimbaTarget.GetWindowTarget(): TWindowHandle;
+begin
+  if Self.FTargetKind <> ESimbaTargetKind.WINDOW then
+    Exit(0);
+  Result := Self.FTargetWindow;
+end;
+
+function TSimbaTarget.GetImageTarget(): TSimbaImage;
+begin
+  if Self.FTargetKind <> ESimbaTargetKind.IMAGE then
+    Exit(nil);
+  Result := Self.FTargetImage;
+end;
+
+function TSimbaTarget.GetEIOSTarget(): TPluginTargetData;
+begin
+  if Self.FTargetKind <> ESimbaTargetKind.EIOS then
+  begin
+    Result.Filename := '';
+    Result.Target := nil;
+    Exit;
+  end;
+
+  Result.Filename := Self.FTargetEIOS.FileName;
+  Result.Target := Self.FTargetEIOS.Target;
+end;
+
+function TSimbaTarget.GetPluginTarget(): TPluginTargetData;
+begin
+  if Self.FTargetKind <> ESimbaTargetKind.PLUGIN then
+  begin
+    Result.Filename := '';
+    Result.Target := nil;
+    Exit;
+  end;
+
+  Result.Filename := Self.FTargetPlugin.FileName;
+  Result.Target := Self.FTargetPlugin.Target;
+end;
+
+
 function TSimbaTarget.ValidateBounds(var ABounds: TBox): Boolean;
 
   procedure ValidateBoundsInCustomClientArea;
@@ -1370,5 +1422,6 @@ begin
       Result += TargetName[FTargetKind];
   end;
 end;
+
 
 end.


### PR DESCRIPTION
I've done this from scratch without following the original so I'm not sure if I did this in a way you would like @ollydev so feel free to edit to your liking or just redo the whole thing.

I'm also not sure if the `TTarget.ImageTarget` I added makes much sense, but I did it for completion sake.
Personally I only need the Window, EIOS and Plugin.

I can imagine `ESimbaTargetKind` having some uses but I only bothered with the things I needed so I don't need to be parsing `TTarget.ToString()` anymore.

I also tested all target kinds and this seems to be working as I would expect but do review please