### PR TITLE
Add TPixelOCR.LoadFont with a TImageArray

### DIFF
--- a/Source/script/imports/simba.import_pixelocr.pas
+++ b/Source/script/imports/simba.import_pixelocr.pas
@@ -14,16 +14,22 @@ implementation
 
 uses
   lptypes, lpvartypes,
-  simba.pixelocr,
+  simba.pixelocr, simba.image,
   simba.script_objectutil;
 
 type
   PPixelFont = ^TPixelFont;
   PPixelOCR = ^TPixelOCR;
+  PSimbaImageArray = ^TSimbaImageArray;
 
-procedure _LapePixelOCR_LoadFont(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
+procedure _LapePixelOCR_LoadFontDir(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
 begin
   PPixelFont(Result)^ := TPixelOCR.LoadFont(PString(Params^[0])^, PInteger(Params^[1])^);
+end;
+
+procedure _LapePixelOCR_LoadFontImgs(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
+begin
+  PPixelFont(Result)^ := TPixelOCR.LoadFont(PSimbaImageArray(Params^[0])^, PInteger(Params^[1])^);
 end;
 
 procedure _LapePixelOCR_TextToTPA(const Params: PParamArray; const Result: Pointer); LAPE_WRAPPER_CALLING_CONV
@@ -115,7 +121,8 @@ begin
     if (getGlobalType('TPixelOCR').Size <> SizeOf(TPixelOCR)) then
       SimbaException('TPixelOCR import is wrong');
 
-    addGlobalFunc('function TPixelOCR.LoadFont(Path: String; SpaceWidth: Integer): TPixelFont; static;', @_LapePixelOCR_LoadFont);
+    addGlobalFunc('function TPixelOCR.LoadFont(Path: String; SpaceWidth: Integer): TPixelFont; static;', @_LapePixelOCR_LoadFontDir);
+    addGlobalFunc('function TPixelOCR.LoadFont(Glyphs: TImageArray; SpaceWidth: Integer): TPixelFont; static; overload;', @_LapePixelOCR_LoadFontImgs);
     addGlobalFunc('function TPixelOCR.TextToTPA(constref Font: TPixelFont; Text: String): TPointArray; static;', @_LapePixelOCR_TextToTPA);
     addGlobalFunc('function TPixelOCR.Locate(Image: TImage; constref Font: TPixelFont; Text: String): Single;', @_LapePixelOCR_Locate);
     addGlobalFunc('function TPixelOCR.Recognize(Image: TImage; constref Font: TPixelFont; P: TPoint): String; overload;', @_LapePixelOCR_Recognize1);

--- a/Source/simba.pixelocr.pas
+++ b/Source/simba.pixelocr.pas
@@ -468,60 +468,60 @@ end;
 class function TPixelOCR.LoadFont(const Images: TSimbaImageArray; SpaceWidth: Integer): TPixelFont;
 var
   Image: TSimbaImage;
-  Files: TStringArray;
   I,J, Count: Integer;
-  Character: String;
   Glyph: TPixelFontGlyph;
   B: TBox;
 begin
   Result := Default(TPixelFont);
   Result.SpaceWidth := SpaceWidth;
 
-  if (Length(Images) <> 255) then
+  if (Length(Images) <> 256) then
     Exit;
-  SetLength(Result.Glyphs, 255);
+  SetLength(Result.Glyphs, 256);
   Count := 0;
 
-  Image := TSimbaImage.Create();
   try
     for I := 0 to High(Images) do
     begin
-        Image := Images[I];
-        Glyph := Default(TPixelFontGlyph);
-        Glyph.Value := Char(I);
-        Glyph.Width := Image.Width;
-        Glyph.Height := Image.Height;
-        if (Glyph.Value > #32) then // not a space
-        begin
-          Glyph.Points := Image.FindColor($FFFFFF, 0, TBox.Create(-1,-1,-1,-1));
-          if (Length(Glyph.Points) = 0) then // if not a space, must have points otherwise skip
-            Continue;
-          Glyph.Shadow := Image.FindColor($0000FF, 0, TBox.Create(-1,-1,-1,-1));
-          Glyph.ForegroundBounds := TPointArray(Glyph.Points + Glyph.Shadow).Bounds;
+      if (I >= 32) and (I <= 126) then
+      begin
+       Image := Images[I];
+       Glyph := Default(TPixelFontGlyph);
+       Glyph.Value := Char(I);
+       Glyph.Width := Image.Width;
+       Glyph.Height := Image.Height;
+       if (Glyph.Value > #32) then // not a space
+       begin
+         Glyph.Points := Image.FindColor($FFFFFF, 0, TBox.Create(-1,-1,-1,-1));
+         if (Length(Glyph.Points) = 0) then // if not a space, must have points otherwise skip
+           Continue;
+         Glyph.Shadow := Image.FindColor($0000FF, 0, TBox.Create(-1,-1,-1,-1));
+         Glyph.ForegroundBounds := TPointArray(Glyph.Points + Glyph.Shadow).Bounds;
 
-          B := Glyph.Points.Bounds;
-          if (B.X1 > 0) then
-          begin
-            Glyph.Points := Glyph.Points.Offset(-B.X1, 0);
-            Glyph.Shadow := Glyph.Shadow.Offset(-B.X1, 0);
-          end;
-          B := TPointArray(Glyph.Points + Glyph.Shadow).Bounds;
+         B := Glyph.Points.Bounds;
+         if (B.X1 > 0) then
+         begin
+           Glyph.Points := Glyph.Points.Offset(-B.X1, 0);
+           Glyph.Shadow := Glyph.Shadow.Offset(-B.X1, 0);
+         end;
+         B := TPointArray(Glyph.Points + Glyph.Shadow).Bounds;
 
-          Glyph.Background := TPointArray(Glyph.Points + Glyph.Shadow).Invert(B.Expand(1));
-          Glyph.BackgroundBounds := B;
-          Glyph.PointsShadowWidth := B.Width;
+         Glyph.Background := TPointArray(Glyph.Points + Glyph.Shadow).Invert(B.Expand(1));
+         Glyph.BackgroundBounds := B;
+         Glyph.PointsShadowWidth := B.Width;
 
-          if (Length(Glyph.Shadow) > 0) then
-            Glyph.BestMatch := Length(Glyph.Points) + Length(Glyph.Shadow)
-          else
-            Glyph.BestMatch := Length(Glyph.Points) + Length(Glyph.Background);
+         if (Length(Glyph.Shadow) > 0) then
+           Glyph.BestMatch := Length(Glyph.Points) + Length(Glyph.Shadow)
+         else
+           Glyph.BestMatch := Length(Glyph.Points) + Length(Glyph.Background);
 
-          Result.MaxGlyphWidth := Max(Result.MaxGlyphWidth, Glyph.Background.Bounds.Width-1);
-          Result.MaxGlyphHeight := Max(Result.MaxGlyphHeight, Glyph.Background.Bounds.Height-1);
-        end;
+         Result.MaxGlyphWidth := Max(Result.MaxGlyphWidth, Glyph.Background.Bounds.Width-1);
+         Result.MaxGlyphHeight := Max(Result.MaxGlyphHeight, Glyph.Background.Bounds.Height-1);
+       end;
 
-        Result.Glyphs[Count] := Glyph;
-        Inc(Count);
+       Result.Glyphs[Count] := Glyph;
+       Inc(Count);
+     end;
     end;
   finally
     SetLength(Result.Glyphs, Count);

--- a/Source/simba.pixelocr.pas
+++ b/Source/simba.pixelocr.pas
@@ -71,7 +71,8 @@ type
     function _RecognizeXY(const Image: TSimbaImage; const Font: PPixelFont; X, Y, Height: Integer; const isBinary: Boolean): TPixelOCRMatch;
   public
     class function LoadFont(Dir: String; SpaceWidth: Integer): TPixelFont; static;
-    class function TextToTPA(constref Font: TPixelFont; Text: String; out Background: TPointArray): TPointArray; overload; static;
+    class function LoadFont(const Images: TSimbaImageArray; SpaceWidth: Integer): TPixelFont; overload; static;
+    class function TextToTPA(constref Font: TPixelFont; Text: String; out Background: TPointArray): TPointArray; static;
     class function TextToTPA(constref Font: TPixelFont; Text: String): TPointArray; overload; static;
 
     function Locate(Image: TSimbaImage; constref Font: TPixelFont; Text: String): Single;
@@ -455,6 +456,75 @@ begin
     SetLength(Result.Glyphs, Count);
 
     Image.Free();
+  end;
+
+  SetLength(Result.GlyphSimilarities, Count, Count);
+  for I := 0 to Count-1 do
+    for J := 0 to Count-1 do
+      if (I <> J) then
+        Result.GlyphSimilarities[I][J] := Round(GlyphSimilarity(Result.Glyphs[I], Result.Glyphs[J]) * 255);
+end;
+
+class function TPixelOCR.LoadFont(const Images: TSimbaImageArray; SpaceWidth: Integer): TPixelFont;
+var
+  Image: TSimbaImage;
+  Files: TStringArray;
+  I,J, Count: Integer;
+  Character: String;
+  Glyph: TPixelFontGlyph;
+  B: TBox;
+begin
+  Result := Default(TPixelFont);
+  Result.SpaceWidth := SpaceWidth;
+
+  if (Length(Images) <> 95) then
+    Exit;
+  SetLength(Result.Glyphs, 95);
+  Count := 0;
+
+  Image := TSimbaImage.Create();
+  try
+    for I := 0 to High(Images) do
+    begin
+        Image := Images[I];
+        Glyph := Default(TPixelFontGlyph);
+        Glyph.Value := Char(I+32);
+        Glyph.Width := Image.Width;
+        Glyph.Height := Image.Height;
+        if (Glyph.Value > #32) then // not a space
+        begin
+          Glyph.Points := Image.FindColor($FFFFFF, 0, TBox.Create(-1,-1,-1,-1));
+          if (Length(Glyph.Points) = 0) then // if not a space, must have points otherwise skip
+            Continue;
+          Glyph.Shadow := Image.FindColor($0000FF, 0, TBox.Create(-1,-1,-1,-1));
+          Glyph.ForegroundBounds := TPointArray(Glyph.Points + Glyph.Shadow).Bounds;
+
+          B := Glyph.Points.Bounds;
+          if (B.X1 > 0) then
+          begin
+            Glyph.Points := Glyph.Points.Offset(-B.X1, 0);
+            Glyph.Shadow := Glyph.Shadow.Offset(-B.X1, 0);
+          end;
+          B := TPointArray(Glyph.Points + Glyph.Shadow).Bounds;
+
+          Glyph.Background := TPointArray(Glyph.Points + Glyph.Shadow).Invert(B.Expand(1));
+          Glyph.BackgroundBounds := B;
+          Glyph.PointsShadowWidth := B.Width;
+
+          if (Length(Glyph.Shadow) > 0) then
+            Glyph.BestMatch := Length(Glyph.Points) + Length(Glyph.Shadow)
+          else
+            Glyph.BestMatch := Length(Glyph.Points) + Length(Glyph.Background);
+
+          Result.MaxGlyphWidth := Max(Result.MaxGlyphWidth, Glyph.Background.Bounds.Width-1);
+          Result.MaxGlyphHeight := Max(Result.MaxGlyphHeight, Glyph.Background.Bounds.Height-1);
+        end;
+
+        Result.Glyphs[Count] := Glyph;
+        Inc(Count);
+    end;
+  finally
+    SetLength(Result.Glyphs, Count);
   end;
 
   SetLength(Result.GlyphSimilarities, Count, Count);

--- a/Source/simba.pixelocr.pas
+++ b/Source/simba.pixelocr.pas
@@ -477,9 +477,9 @@ begin
   Result := Default(TPixelFont);
   Result.SpaceWidth := SpaceWidth;
 
-  if (Length(Images) <> 95) then
+  if (Length(Images) <> 255) then
     Exit;
-  SetLength(Result.Glyphs, 95);
+  SetLength(Result.Glyphs, 255);
   Count := 0;
 
   Image := TSimbaImage.Create();
@@ -488,7 +488,7 @@ begin
     begin
         Image := Images[I];
         Glyph := Default(TPixelFontGlyph);
-        Glyph.Value := Char(I+32);
+        Glyph.Value := Char(I);
         Glyph.Width := Image.Width;
         Glyph.Height := Image.Height;
         if (Glyph.Value > #32) then // not a space


### PR DESCRIPTION
I only did a compile test of Simba and ran it just to be sure it compiled properly but I did not actually test this as I don't have enough stuff to test it yet sadly but I think I did it properly.

Anyways, this allows people (me) to load a font with images instead of a font path.
It requires a TImageArray with exactly 255 images to be used even if a bunch of them end up being skipped because they are spaces.
Also, their index should be their char code